### PR TITLE
fix(security): evict stale entries from the OIDC rate limiter

### DIFF
--- a/Jellyfin.Plugin.OIDC.Tests/Services/RateLimitFilterTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/Services/RateLimitFilterTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Reflection;
 using Jellyfin.Plugin.OIDC.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -153,5 +154,38 @@ public class RateLimitFilterTests
 
         Assert.True(called);
         Assert.Null(afterReset.Result);
+    }
+
+    // ── stale-entry cleanup ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Cleanup_RemovesEntriesOlderThanMaxStaleAge_KeepsFreshOnes()
+    {
+        var stalePolicy = NextPolicy();
+        var freshPolicy = NextPolicy();
+
+        var freshFilter = new RateLimitAttribute(freshPolicy, maxRequests: 5, windowSeconds: 60);
+        await freshFilter.OnActionExecutionAsync(MakeContext("1.1.1.1"), MakeDelegate());
+
+        var staleFilter = new RateLimitAttribute(stalePolicy, maxRequests: 5, windowSeconds: 60);
+        await staleFilter.OnActionExecutionAsync(MakeContext("2.2.2.2"), MakeDelegate());
+
+        // Rewrite the stale entry's WindowStart far in the past via reflection — the only way
+        // to simulate staleness without an actual 10+ minute sleep in the test.
+        var countersField = typeof(RateLimitAttribute).GetField("_counters", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var counters = (System.Collections.IDictionary)countersField.GetValue(null)!;
+        var staleKey = $"{stalePolicy}:2.2.2.2";
+        var freshKey = $"{freshPolicy}:1.1.1.1";
+        var entryType = counters[staleKey]!.GetType();
+        var staleEntry = Activator.CreateInstance(entryType)!;
+        entryType.GetProperty("Count")!.SetValue(staleEntry, 1);
+        entryType.GetProperty("WindowStart")!.SetValue(staleEntry, DateTimeOffset.UtcNow.AddMinutes(-20));
+        counters[staleKey] = staleEntry;
+
+        var cleanup = typeof(RateLimitAttribute).GetMethod("Cleanup", BindingFlags.NonPublic | BindingFlags.Static)!;
+        cleanup.Invoke(null, [null]);
+
+        Assert.False(counters.Contains(staleKey));
+        Assert.True(counters.Contains(freshKey));
     }
 }

--- a/Jellyfin.Plugin.OIDC/Services/RateLimitFilter.cs
+++ b/Jellyfin.Plugin.OIDC/Services/RateLimitFilter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -16,6 +17,15 @@ public sealed class RateLimitAttribute : Attribute, IAsyncActionFilter
 {
     // Shared across all instances: key = "policyName:clientIP"
     private static readonly ConcurrentDictionary<string, RateLimitEntry> _counters = new();
+
+    // Kept well above the largest windowSeconds configured on any [RateLimit] usage (60s today),
+    // so cleanup never evicts an entry that's still relevant to active rate limiting.
+    private static readonly TimeSpan MaxStaleAge = TimeSpan.FromSeconds(600);
+    private static readonly TimeSpan CleanupInterval = TimeSpan.FromMinutes(5);
+
+    // Without this, every distinct "policyName:IP" that ever hits a rate-limited endpoint would
+    // leak permanently — unbounded memory growth over the life of the process.
+    private static readonly Timer _cleanupTimer = new(Cleanup, null, CleanupInterval, CleanupInterval);
 
     private readonly int _maxRequests;
     private readonly int _windowSeconds;
@@ -65,6 +75,18 @@ public sealed class RateLimitAttribute : Attribute, IAsyncActionFilter
         // Jellyfin honours X-Forwarded-For for trusted proxies, which updates
         // RemoteIpAddress via its own middleware. Use it directly.
         return context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+    }
+
+    internal static void Cleanup(object? state)
+    {
+        var cutoff = DateTimeOffset.UtcNow - MaxStaleAge;
+        foreach (var (key, entry) in _counters)
+        {
+            if (entry.WindowStart < cutoff)
+            {
+                _counters.TryRemove(key, out _);
+            }
+        }
     }
 
     private sealed class RateLimitEntry


### PR DESCRIPTION
## Summary
- `RateLimitAttribute`'s per-IP counter dictionary never evicted old entries — every distinct `policy:IP` that hit a rate-limited OIDC endpoint (`Start`/`Callback`/`Auth`) leaked for the life of the process, an unbounded-memory-growth DoS.
- Adds a periodic cleanup timer (5-minute interval, 10-minute staleness threshold — well above the 60s windows currently configured) that evicts expired entries, mirroring the pattern `StateManager` already uses for the same reason.

## Test plan
- [x] `dotnet build -c Release` — clean
- [x] `dotnet test -c Release` — 177/177 passing, including a new `Cleanup_RemovesEntriesOlderThanMaxStaleAge_KeepsFreshOnes` test