### PR TITLE
fix(security): validate OIDC picture-claim URL before fetching (SSRF)

### DIFF
--- a/Jellyfin.Plugin.OIDC.Tests/Fixtures/MockHttpMessageHandler.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/Fixtures/MockHttpMessageHandler.cs
@@ -11,12 +11,19 @@ public sealed class MockHttpMessageHandler : HttpMessageHandler
 {
     private readonly HttpResponseMessage _response;
 
-    public MockHttpMessageHandler(HttpStatusCode statusCode, string content, string contentType = "application/json")
+    public MockHttpMessageHandler(
+        HttpStatusCode statusCode, string content, string contentType = "application/json", long? contentLengthOverride = null)
     {
         _response = new HttpResponseMessage(statusCode)
         {
             Content = new StringContent(content, System.Text.Encoding.UTF8, contentType)
         };
+
+        // Lets tests simulate a server advertising a large body without actually allocating it.
+        if (contentLengthOverride.HasValue)
+        {
+            _response.Content.Headers.ContentLength = contentLengthOverride.Value;
+        }
     }
 
     protected override Task<HttpResponseMessage> SendAsync(

--- a/Jellyfin.Plugin.OIDC.Tests/Services/ProfileImageServiceTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/Services/ProfileImageServiceTests.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.OIDC.Configuration;
 using Jellyfin.Plugin.OIDC.Services;
 using Jellyfin.Plugin.OIDC.Tests.Fixtures;
 using MediaBrowser.Controller;
@@ -17,15 +18,26 @@ using Xunit;
 
 namespace Jellyfin.Plugin.OIDC.Tests.Services;
 
+[Xunit.Collection("OidcPlugin")]
 public class ProfileImageServiceTests
 {
     private const string OidcAuthProviderId = "Jellyfin.Plugin.OIDC.Auth.OidcAuthProvider";
+
+    // A public IP literal — AuthorityGuard.ValidateAsync passes it without a real DNS lookup,
+    // keeping these tests fast and network-independent (mirrors AuthorityGuardTests' convention).
+    private const string PublicPictureUrl = "https://8.8.8.8/avatar.png";
+    private const string LoopbackPictureUrl = "https://127.0.0.1/avatar.png";
+    private const string TestProviderId = "testprovider";
+
+    private readonly PluginTestFixture _fixture;
+
+    public ProfileImageServiceTests(PluginTestFixture fixture) => _fixture = fixture;
 
     private static (ProfileImageService Service, IUserManager UserManager, IProviderManager ProviderManager) MakeService(
         HttpMessageHandler handler)
     {
         var httpClientFactory = Substitute.For<IHttpClientFactory>();
-        httpClientFactory.CreateClient("OidcPlugin").Returns(new HttpClient(handler));
+        httpClientFactory.CreateClient("OidcPluginImage").Returns(new HttpClient(handler));
 
         var userManager = Substitute.For<IUserManager>();
         userManager.UpdateUserAsync(Arg.Any<User>()).Returns(Task.CompletedTask);
@@ -47,6 +59,21 @@ public class ProfileImageServiceTests
 
     private static User MakeUser(string username = "alice") => new(username, OidcAuthProviderId, "PasswordResetProviderId");
 
+    private void SetProviderConfig(bool allowLoopback = false, bool allowLinkLocal = false, bool blockPrivateNetworks = false) =>
+        _fixture.SetConfiguration(new PluginConfiguration
+        {
+            Providers =
+            [
+                new OidcProviderConfig
+                {
+                    ProviderId = TestProviderId,
+                    AllowLoopbackAuthority = allowLoopback,
+                    AllowLinkLocalAuthority = allowLinkLocal
+                }
+            ],
+            BlockPrivateNetworkAuthorities = blockPrivateNetworks
+        });
+
     // ── no-op guard clauses ────────────────────────────────────────────────────
 
     [Fact]
@@ -56,7 +83,7 @@ public class ProfileImageServiceTests
         var (service, userManager, _) = MakeService(new ThrowingHttpMessageHandler(new HttpRequestException("should never be called")));
 
         // Act
-        await service.ApplyProfileImageAsync(Guid.NewGuid(), null);
+        await service.ApplyProfileImageAsync(Guid.NewGuid(), null, TestProviderId);
 
         // Assert
         userManager.DidNotReceive().GetUserById(Arg.Any<Guid>());
@@ -67,7 +94,7 @@ public class ProfileImageServiceTests
     {
         var (service, userManager, _) = MakeService(new ThrowingHttpMessageHandler(new HttpRequestException("should never be called")));
 
-        await service.ApplyProfileImageAsync(Guid.NewGuid(), string.Empty);
+        await service.ApplyProfileImageAsync(Guid.NewGuid(), string.Empty, TestProviderId);
 
         userManager.DidNotReceive().GetUserById(Arg.Any<Guid>());
     }
@@ -77,9 +104,66 @@ public class ProfileImageServiceTests
     {
         var (service, userManager, _) = MakeService(new ThrowingHttpMessageHandler(new HttpRequestException("should never be called")));
 
-        await service.ApplyProfileImageAsync(Guid.NewGuid(), "   ");
+        await service.ApplyProfileImageAsync(Guid.NewGuid(), "   ", TestProviderId);
 
         userManager.DidNotReceive().GetUserById(Arg.Any<Guid>());
+    }
+
+    // ── SSRF guard ──────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("ftp://8.8.8.8/avatar.png")]
+    [InlineData("file:///etc/passwd")]
+    public async Task DisallowedScheme_DoesNotSaveImage(string url)
+    {
+        SetProviderConfig();
+        var (service, userManager, providerManager) =
+            MakeService(new ThrowingHttpMessageHandler(new HttpRequestException("should never be called")));
+        userManager.GetUserById(Arg.Any<Guid>()).Returns(MakeUser());
+
+        await service.ApplyProfileImageAsync(Guid.NewGuid(), url, TestProviderId);
+
+        await providerManager.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task LoopbackUrl_ProviderDoesNotAllowLoopback_DoesNotSaveImage()
+    {
+        SetProviderConfig(allowLoopback: false);
+        var (service, userManager, providerManager) =
+            MakeService(new ThrowingHttpMessageHandler(new HttpRequestException("should never be called")));
+        userManager.GetUserById(Arg.Any<Guid>()).Returns(MakeUser());
+
+        await service.ApplyProfileImageAsync(Guid.NewGuid(), LoopbackPictureUrl, TestProviderId);
+
+        await providerManager.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task LoopbackUrl_ProviderAllowsLoopback_Proceeds()
+    {
+        SetProviderConfig(allowLoopback: true);
+        var (service, userManager, providerManager) =
+            MakeService(new MockHttpMessageHandler(HttpStatusCode.OK, "binary-data", "image/png"));
+        userManager.GetUserById(Arg.Any<Guid>()).Returns(MakeUser());
+
+        await service.ApplyProfileImageAsync(Guid.NewGuid(), LoopbackPictureUrl, TestProviderId);
+
+        await providerManager.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task UnknownProviderId_TreatedAsNoOptOuts_LoopbackBlocked()
+    {
+        // No provider config matches this ID — the guard must fail closed (no opt-outs), not throw.
+        SetProviderConfig();
+        var (service, userManager, providerManager) =
+            MakeService(new ThrowingHttpMessageHandler(new HttpRequestException("should never be called")));
+        userManager.GetUserById(Arg.Any<Guid>()).Returns(MakeUser());
+
+        await service.ApplyProfileImageAsync(Guid.NewGuid(), LoopbackPictureUrl, "unknown-provider");
+
+        await providerManager.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
     }
 
     // ── download / validation failures never save, never throw ────────────────
@@ -87,11 +171,12 @@ public class ProfileImageServiceTests
     [Fact]
     public async Task NonSuccessStatusCode_DoesNotSaveImage()
     {
+        SetProviderConfig();
         var (service, userManager, providerManager) =
             MakeService(new MockHttpMessageHandler(HttpStatusCode.NotFound, "not found", "text/plain"));
         userManager.GetUserById(Arg.Any<Guid>()).Returns(MakeUser());
 
-        await service.ApplyProfileImageAsync(Guid.NewGuid(), "https://idp.example.com/avatar.png");
+        await service.ApplyProfileImageAsync(Guid.NewGuid(), PublicPictureUrl, TestProviderId);
 
         await providerManager.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
     }
@@ -99,11 +184,25 @@ public class ProfileImageServiceTests
     [Fact]
     public async Task NonImageContentType_DoesNotSaveImage()
     {
+        SetProviderConfig();
         var (service, userManager, providerManager) =
             MakeService(new MockHttpMessageHandler(HttpStatusCode.OK, "<html></html>", "text/html"));
         userManager.GetUserById(Arg.Any<Guid>()).Returns(MakeUser());
 
-        await service.ApplyProfileImageAsync(Guid.NewGuid(), "https://idp.example.com/avatar.png");
+        await service.ApplyProfileImageAsync(Guid.NewGuid(), PublicPictureUrl, TestProviderId);
+
+        await providerManager.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task OversizedContentLength_DoesNotSaveImage()
+    {
+        SetProviderConfig();
+        var (service, userManager, providerManager) =
+            MakeService(new MockHttpMessageHandler(HttpStatusCode.OK, new string('a', 100), "image/png", contentLengthOverride: 10L * 1024 * 1024));
+        userManager.GetUserById(Arg.Any<Guid>()).Returns(MakeUser());
+
+        await service.ApplyProfileImageAsync(Guid.NewGuid(), PublicPictureUrl, TestProviderId);
 
         await providerManager.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
     }
@@ -111,11 +210,12 @@ public class ProfileImageServiceTests
     [Fact]
     public async Task UserNotFound_DoesNotSaveImage()
     {
+        SetProviderConfig();
         var (service, userManager, providerManager) =
             MakeService(new MockHttpMessageHandler(HttpStatusCode.OK, "binary-data", "image/png"));
         userManager.GetUserById(Arg.Any<Guid>()).Returns((User?)null);
 
-        await service.ApplyProfileImageAsync(Guid.NewGuid(), "https://idp.example.com/avatar.png");
+        await service.ApplyProfileImageAsync(Guid.NewGuid(), PublicPictureUrl, TestProviderId);
 
         await providerManager.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
     }
@@ -124,16 +224,18 @@ public class ProfileImageServiceTests
     public async Task HttpTransportThrows_DoesNotThrow()
     {
         // Avatar sync must never break login — success is simply not throwing.
+        SetProviderConfig();
         var (service, userManager, _) =
             MakeService(new ThrowingHttpMessageHandler(new HttpRequestException("No route to host")));
         userManager.GetUserById(Arg.Any<Guid>()).Returns(MakeUser());
 
-        await service.ApplyProfileImageAsync(Guid.NewGuid(), "https://idp.example.com/avatar.png");
+        await service.ApplyProfileImageAsync(Guid.NewGuid(), PublicPictureUrl, TestProviderId);
     }
 
     [Fact]
     public async Task SaveImageThrows_DoesNotThrow()
     {
+        SetProviderConfig();
         var (service, userManager, providerManager) =
             MakeService(new MockHttpMessageHandler(HttpStatusCode.OK, "binary-data", "image/png"));
         var userId = Guid.NewGuid();
@@ -141,7 +243,7 @@ public class ProfileImageServiceTests
         providerManager.SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>())
             .Returns(_ => throw new IOException("disk full"));
 
-        await service.ApplyProfileImageAsync(userId, "https://idp.example.com/avatar.png");
+        await service.ApplyProfileImageAsync(userId, PublicPictureUrl, TestProviderId);
     }
 
     // ── success path ───────────────────────────────────────────────────────────
@@ -149,12 +251,13 @@ public class ProfileImageServiceTests
     [Fact]
     public async Task Success_SavesImageWithDownloadedMimeType()
     {
+        SetProviderConfig();
         var (service, userManager, providerManager) =
             MakeService(new MockHttpMessageHandler(HttpStatusCode.OK, "binary-data", "image/png"));
         var userId = Guid.NewGuid();
         userManager.GetUserById(userId).Returns(MakeUser());
 
-        await service.ApplyProfileImageAsync(userId, "https://idp.example.com/avatar.png");
+        await service.ApplyProfileImageAsync(userId, PublicPictureUrl, TestProviderId);
 
         await providerManager.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", Arg.Any<string>());
     }
@@ -162,13 +265,14 @@ public class ProfileImageServiceTests
     [Fact]
     public async Task Success_UpdatesUser()
     {
+        SetProviderConfig();
         var (service, userManager, _) =
             MakeService(new MockHttpMessageHandler(HttpStatusCode.OK, "binary-data", "image/png"));
         var userId = Guid.NewGuid();
         var user = MakeUser();
         userManager.GetUserById(userId).Returns(user);
 
-        await service.ApplyProfileImageAsync(userId, "https://idp.example.com/avatar.png");
+        await service.ApplyProfileImageAsync(userId, PublicPictureUrl, TestProviderId);
 
         await userManager.Received(1).UpdateUserAsync(user);
     }
@@ -176,13 +280,14 @@ public class ProfileImageServiceTests
     [Fact]
     public async Task Success_SetsProfileImagePathWithMatchingExtension()
     {
+        SetProviderConfig();
         var (service, userManager, _) =
             MakeService(new MockHttpMessageHandler(HttpStatusCode.OK, "binary-data", "image/png"));
         var userId = Guid.NewGuid();
         var user = MakeUser();
         userManager.GetUserById(userId).Returns(user);
 
-        await service.ApplyProfileImageAsync(userId, "https://idp.example.com/avatar.png");
+        await service.ApplyProfileImageAsync(userId, PublicPictureUrl, TestProviderId);
 
         Assert.NotNull(user.ProfileImage);
         Assert.EndsWith(".png", user.ProfileImage!.Path);
@@ -191,6 +296,7 @@ public class ProfileImageServiceTests
     [Fact]
     public async Task ExistingProfileImage_IsClearedBeforeSettingNewOne()
     {
+        SetProviderConfig();
         var (service, userManager, _) =
             MakeService(new MockHttpMessageHandler(HttpStatusCode.OK, "binary-data", "image/png"));
         var userId = Guid.NewGuid();
@@ -198,7 +304,7 @@ public class ProfileImageServiceTests
         user.ProfileImage = new ImageInfo("/existing/old-avatar.jpg");
         userManager.GetUserById(userId).Returns(user);
 
-        await service.ApplyProfileImageAsync(userId, "https://idp.example.com/avatar.png");
+        await service.ApplyProfileImageAsync(userId, PublicPictureUrl, TestProviderId);
 
         await userManager.Received(1).ClearProfileImageAsync(user);
     }
@@ -206,13 +312,14 @@ public class ProfileImageServiceTests
     [Fact]
     public async Task NoExistingProfileImage_DoesNotCallClear()
     {
+        SetProviderConfig();
         var (service, userManager, _) =
             MakeService(new MockHttpMessageHandler(HttpStatusCode.OK, "binary-data", "image/png"));
         var userId = Guid.NewGuid();
         var user = MakeUser();
         userManager.GetUserById(userId).Returns(user);
 
-        await service.ApplyProfileImageAsync(userId, "https://idp.example.com/avatar.png");
+        await service.ApplyProfileImageAsync(userId, PublicPictureUrl, TestProviderId);
 
         await userManager.DidNotReceive().ClearProfileImageAsync(Arg.Any<User>());
     }

--- a/Jellyfin.Plugin.OIDC/Api/OidcController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/OidcController.cs
@@ -440,7 +440,7 @@ public class OidcController : ControllerBase
             // Apply RBAC via UpdatePolicyAsync BEFORE AuthenticateDirect so that
             // Jellyfin's runtime user state is correct when the session token is minted.
             await _userSyncService.ApplyRolesAsync(userId, session.Roles, session.ProviderId).ConfigureAwait(false);
-            await _userSyncService.ApplyProfileImageAsync(userId, session.PictureUrl).ConfigureAwait(false);
+            await _userSyncService.ApplyProfileImageAsync(userId, session.PictureUrl, session.ProviderId).ConfigureAwait(false);
 
             var authRequest = new AuthenticationRequest
             {
@@ -506,7 +506,7 @@ public class OidcController : ControllerBase
         {
             userId = await _userSyncService.SyncUserAsync(session.Username, session.DisplayName, session.ProviderId).ConfigureAwait(false);
             await _userSyncService.ApplyRolesAsync(userId, session.Roles, session.ProviderId).ConfigureAwait(false);
-            await _userSyncService.ApplyProfileImageAsync(userId, session.PictureUrl).ConfigureAwait(false);
+            await _userSyncService.ApplyProfileImageAsync(userId, session.PictureUrl, session.ProviderId).ConfigureAwait(false);
         }
         catch (InvalidOperationException ex)
         {

--- a/Jellyfin.Plugin.OIDC/Services/ProfileImageService.cs
+++ b/Jellyfin.Plugin.OIDC/Services/ProfileImageService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
@@ -12,6 +13,11 @@ namespace Jellyfin.Plugin.OIDC.Services;
 
 public class ProfileImageService
 {
+    // Cap the download so a malicious/compromised picture-claim host can't exhaust memory or
+    // disk via an oversized response. Partial mitigation: a host that omits Content-Length
+    // isn't caught by this check, only by whatever limits the underlying HttpClient applies.
+    private const long MaxProfileImageBytes = 5 * 1024 * 1024;
+
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IUserManager _userManager;
     private readonly IServerConfigurationManager _serverConfigurationManager;
@@ -36,22 +42,55 @@ public class ProfileImageService
     /// Downloads the image at <paramref name="pictureUrl"/> and sets it as the user's profile
     /// image, overwriting any existing one. Never throws: avatar sync must not break login.
     /// </summary>
-    public async Task ApplyProfileImageAsync(Guid userId, string? pictureUrl)
+    public async Task ApplyProfileImageAsync(Guid userId, string? pictureUrl, string providerId)
     {
         if (string.IsNullOrWhiteSpace(pictureUrl))
         {
             return;
         }
 
+        if (!Uri.TryCreate(pictureUrl, UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            _logger.LogWarning("Rejected profile image URL with disallowed scheme: {Url}", pictureUrl);
+            return;
+        }
+
+        // The picture claim can come from the IdP's userinfo/token payload — and on some IdPs
+        // (e.g. Keycloak, Authentik) end users can set it themselves — so it gets the same
+        // SSRF guard as Authority, using that provider's own loopback/link-local trust settings.
+        var provider = OidcPlugin.Instance?.Configuration?.Providers
+            .FirstOrDefault(p => string.Equals(p.ProviderId, providerId, StringComparison.OrdinalIgnoreCase));
+        var blockPrivateNetworks = OidcPlugin.Instance?.Configuration?.BlockPrivateNetworkAuthorities ?? false;
+        var blockReason = await AuthorityGuard.ValidateAsync(
+            pictureUrl,
+            provider?.AllowLoopbackAuthority ?? false,
+            provider?.AllowLinkLocalAuthority ?? false,
+            blockPrivateNetworks).ConfigureAwait(false);
+        if (blockReason != null)
+        {
+            _logger.LogWarning("Blocked profile image fetch for {Url}: {Reason}", pictureUrl, blockReason);
+            return;
+        }
+
         try
         {
-            var httpClient = _httpClientFactory.CreateClient("OidcPlugin");
+            var httpClient = _httpClientFactory.CreateClient("OidcPluginImage");
             using var response = await httpClient.GetAsync(pictureUrl).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogWarning(
                     "Failed to download profile image from {Url}: HTTP {Status}",
                     pictureUrl, (int)response.StatusCode);
+                return;
+            }
+
+            var contentLength = response.Content.Headers.ContentLength;
+            if (contentLength.HasValue && contentLength.Value > MaxProfileImageBytes)
+            {
+                _logger.LogWarning(
+                    "Profile image at {Url} exceeds the {MaxBytes}-byte limit (Content-Length: {Length})",
+                    pictureUrl, MaxProfileImageBytes, contentLength.Value);
                 return;
             }
 

--- a/Jellyfin.Plugin.OIDC/Services/ServiceRegistrator.cs
+++ b/Jellyfin.Plugin.OIDC/Services/ServiceRegistrator.cs
@@ -12,6 +12,12 @@ public class ServiceRegistrator : IPluginServiceRegistrator
         serviceCollection.AddSingleton<IAuthenticationProvider, Auth.OidcAuthProvider>();
         serviceCollection.AddSingleton<StateManager>();
         serviceCollection.AddHostedService(sp => sp.GetRequiredService<StateManager>());
+
+        // Dedicated client for profile-image downloads: redirects disabled so a validated
+        // picture URL can't be used to bounce the request to an unvalidated internal host.
+        serviceCollection.AddHttpClient("OidcPluginImage")
+            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { AllowAutoRedirect = false });
+
         serviceCollection.AddScoped<RbacService>();
         serviceCollection.AddScoped<ProfileImageService>();
         serviceCollection.AddScoped<UserSyncService>();

--- a/Jellyfin.Plugin.OIDC/Services/UserSyncService.cs
+++ b/Jellyfin.Plugin.OIDC/Services/UserSyncService.cs
@@ -153,6 +153,6 @@ public class UserSyncService
     public Task ApplyRolesAsync(Guid userId, string[] roles, string providerId)
         => _rbacService.ApplyRoleMappingsAsync(userId, roles, providerId);
 
-    public Task ApplyProfileImageAsync(Guid userId, string? pictureUrl)
-        => _profileImageService.ApplyProfileImageAsync(userId, pictureUrl);
+    public Task ApplyProfileImageAsync(Guid userId, string? pictureUrl, string providerId)
+        => _profileImageService.ApplyProfileImageAsync(userId, pictureUrl, providerId);
 }


### PR DESCRIPTION
## Summary
- `ProfileImageService` fetched the `picture` claim URL (from the ID token, access token, or `/userinfo` — provider- and sometimes end-user-controlled on IdPs like Keycloak/Authentik) with zero host validation, unlike `Authority`, which `AuthorityGuard` already protects.
- A malicious/compromised IdP, or an end user who can set their own picture attribute, could point it at an internal service or cloud metadata endpoint and have the server fetch it, storing the response as the user's avatar.

## Changes
- Reject non-http(s) schemes outright.
- Run the picture URL through `AuthorityGuard.ValidateAsync` using that provider's own `AllowLoopbackAuthority`/`AllowLinkLocalAuthority` settings plus the global `BlockPrivateNetworkAuthorities` toggle — consistent with how `Authority` is already treated, so it doesn't break self-hosted setups where the IdP and its avatars live on a private network the admin already trusted.
- Fetch through a dedicated `OidcPluginImage` client with redirects disabled, so a validated URL can't be used to bounce the request to an unvalidated host via a 3xx response.
- Cap the response at 5MB via `Content-Length` before reading the body.
- Thread `providerId` through `UserSyncService`/`OidcController` so `ProfileImageService` can look up the right provider's trust settings.

## Test plan
- [x] `dotnet build -c Release` — clean
- [x] `dotnet test -c Release` — 182/182 passing, including new SSRF-guard coverage (disallowed schemes, loopback blocked/allowed per provider config, unknown provider fails closed, oversized `Content-Length` rejected)