### PR TITLE
fix(security): block disabled providers during an active session-token window

### DIFF
--- a/Jellyfin.Plugin.OIDC.Tests/Api/OidcControllerTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/Api/OidcControllerTests.cs
@@ -441,6 +441,44 @@ public class OidcControllerTests
         Assert.DoesNotContain("const providerId = 'kc'", html);
     }
 
+    // ── Authenticate ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Authenticate_ProviderDisabled_ReturnsNotFound()
+    {
+        // Arrange — provider existed when the session was authorized but was disabled afterward;
+        // the session token (5-minute TTL) must not still let the login through.
+        _fixture.SetConfiguration(new PluginConfiguration
+        {
+            Providers = [new OidcProviderConfig { ProviderId = "keycloak", Enabled = false }]
+        });
+        var stateManager = new StateManager(NullLogger<StateManager>.Instance);
+        var token = stateManager.StoreAuthorizedSession(MakeQcSession(username: "alice", providerId: "keycloak"));
+        var controller = MakeController(stateManager: stateManager);
+
+        // Act
+        var result = await controller.Authenticate("keycloak", new AuthenticateRequest { Token = token! });
+
+        // Assert
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Authenticate_ProviderRemoved_ReturnsNotFound()
+    {
+        // Arrange — no provider configured at all (e.g. removed from the admin UI mid-flow).
+        _fixture.SetConfiguration(new PluginConfiguration());
+        var stateManager = new StateManager(NullLogger<StateManager>.Instance);
+        var token = stateManager.StoreAuthorizedSession(MakeQcSession(username: "alice", providerId: "keycloak"));
+        var controller = MakeController(stateManager: stateManager);
+
+        // Act
+        var result = await controller.Authenticate("keycloak", new AuthenticateRequest { Token = token! });
+
+        // Assert
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
     // ── QuickConnectAuthorize ──────────────────────────────────────────────────
 
     private static AuthorizedSession MakeQcSession(
@@ -469,7 +507,8 @@ public class OidcControllerTests
         _fixture.SetConfiguration(new PluginConfiguration
         {
             AutoCreateUsers = true,
-            UserProviderMap = [new UserProviderEntry { Username = username, ProviderId = providerId }]
+            UserProviderMap = [new UserProviderEntry { Username = username, ProviderId = providerId }],
+            Providers = [new OidcProviderConfig { ProviderId = providerId, Enabled = true }]
         });
 
     [Fact]
@@ -503,9 +542,33 @@ public class OidcControllerTests
     }
 
     [Fact]
+    public async Task QuickConnectAuthorize_ProviderDisabled_ReturnsNotFound()
+    {
+        // Arrange — provider existed when the session was authorized but was disabled afterward.
+        _fixture.SetConfiguration(new PluginConfiguration
+        {
+            Providers = [new OidcProviderConfig { ProviderId = "keycloak", Enabled = false }]
+        });
+        var stateManager = new StateManager(NullLogger<StateManager>.Instance);
+        var token = stateManager.StoreAuthorizedSession(MakeQcSession(username: "alice", providerId: "keycloak"));
+        var controller = MakeController(stateManager: stateManager);
+
+        // Act
+        var result = await controller.QuickConnectAuthorize(
+            "keycloak", new QuickConnectAuthorizeRequest { Token = token!, Code = "123456" });
+
+        // Assert
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
     public async Task QuickConnectAuthorize_QuickConnectDisabled_ReturnsBadRequest()
     {
         // Arrange
+        _fixture.SetConfiguration(new PluginConfiguration
+        {
+            Providers = [new OidcProviderConfig { ProviderId = "keycloak", Enabled = true }]
+        });
         var stateManager = new StateManager(NullLogger<StateManager>.Instance);
         var token = stateManager.StoreAuthorizedSession(MakeQcSession());
         var quickConnect = Substitute.For<IQuickConnect>();
@@ -526,6 +589,10 @@ public class OidcControllerTests
     public async Task QuickConnectAuthorize_MissingCode_ReturnsBadRequest()
     {
         // Arrange
+        _fixture.SetConfiguration(new PluginConfiguration
+        {
+            Providers = [new OidcProviderConfig { ProviderId = "keycloak", Enabled = true }]
+        });
         var stateManager = new StateManager(NullLogger<StateManager>.Instance);
         var token = stateManager.StoreAuthorizedSession(MakeQcSession());
         var controller = MakeController(stateManager: stateManager);
@@ -546,7 +613,11 @@ public class OidcControllerTests
         var token = stateManager.StoreAuthorizedSession(MakeQcSession(username: "unknown-user"));
         var userManager = Substitute.For<IUserManager>();
         userManager.GetUserByName("unknown-user").Returns((User?)null);
-        _fixture.SetConfiguration(new PluginConfiguration { AutoCreateUsers = false });
+        _fixture.SetConfiguration(new PluginConfiguration
+        {
+            AutoCreateUsers = false,
+            Providers = [new OidcProviderConfig { ProviderId = "keycloak", Enabled = true }]
+        });
         var controller = MakeController(stateManager: stateManager, userManager: userManager);
 
         // Act

--- a/Jellyfin.Plugin.OIDC/Api/OidcController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/OidcController.cs
@@ -433,6 +433,11 @@ public class OidcController : ControllerBase
             return BadRequest("Provider mismatch");
         }
 
+        if (GetProvider(providerId) == null)
+        {
+            return NotFound($"Provider '{providerId}' not found or disabled");
+        }
+
         try
         {
             var userId = await _userSyncService.SyncUserAsync(session.Username, session.DisplayName, session.ProviderId).ConfigureAwait(false);
@@ -488,6 +493,11 @@ public class OidcController : ControllerBase
         if (!string.Equals(session.ProviderId, providerId, StringComparison.OrdinalIgnoreCase))
         {
             return BadRequest("Provider mismatch");
+        }
+
+        if (GetProvider(providerId) == null)
+        {
+            return NotFound($"Provider '{providerId}' not found or disabled");
         }
 
         if (!_quickConnect.IsEnabled)


### PR DESCRIPTION
## Summary
- `Authenticate` and `QuickConnectAuthorize` checked that the authorized session's `ProviderId` matched the requested `providerId`, but never re-checked that the provider was still enabled — unlike `Start`/`Callback`, which both gate on `GetProvider`.
- If an admin disabled a provider mid-flow, a session token minted moments earlier (up to a 5-minute TTL) could still complete login or Quick Connect authorization for that provider.

## Changes
- Add the same `GetProvider(providerId) == null` check `Start`/`Callback` already use to both `Authenticate` and `QuickConnectAuthorize`.

## Test plan
- [x] `dotnet build -c Release` — clean
- [x] `dotnet test -c Release` — 179/179 passing, including new `Authenticate_ProviderDisabled_ReturnsNotFound`, `Authenticate_ProviderRemoved_ReturnsNotFound`, and `QuickConnectAuthorize_ProviderDisabled_ReturnsNotFound` tests