### PR TITLE
fix(security): close DNS-rebinding TOCTOU gap in AuthorityGuard

### DIFF
--- a/Jellyfin.Plugin.OIDC.Tests/Api/ConfigControllerTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/Api/ConfigControllerTests.cs
@@ -41,7 +41,12 @@ public class ConfigControllerTests
         var httpClientFactory = Substitute.For<IHttpClientFactory>();
         httpClientFactory.CreateClient("OidcPlugin").Returns(new HttpClient(handler));
 
-        return new ConfigController(rbacService, httpClientFactory, NullLogger<ConfigController>.Instance);
+        // Tests use IP-literal Authorities, so AuthorityGuard always resolves a pinned address —
+        // route the "pinned" path through the same mock handler instead of a real socket
+        // connection, matching how the fallback ("OidcPlugin") path is already mocked above.
+        HttpClient PinnedClientFactory(IPAddress _, bool __) => new(handler);
+
+        return new ConfigController(rbacService, httpClientFactory, PinnedClientFactory, NullLogger<ConfigController>.Instance);
     }
 
     [Fact]

--- a/Jellyfin.Plugin.OIDC.Tests/Api/OidcControllerTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/Api/OidcControllerTests.cs
@@ -471,6 +471,8 @@ public class OidcControllerTests
 
         // Assert
         Assert.Contains("<script nonce=\"abc123==\">", html);
+    }
+
     // ── Authenticate ───────────────────────────────────────────────────────────
 
     [Fact]

--- a/Jellyfin.Plugin.OIDC.Tests/Api/OidcControllerTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/Api/OidcControllerTests.cs
@@ -7,6 +7,7 @@ using Jellyfin.Plugin.OIDC.Api;
 using Jellyfin.Plugin.OIDC.Configuration;
 using Jellyfin.Plugin.OIDC.Services;
 using Jellyfin.Plugin.OIDC.Tests.Fixtures;
+using System.Net;
 using System.Net.Http;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Configuration;
@@ -41,8 +42,14 @@ public class OidcControllerTests
         var libraryManager = Substitute.For<ILibraryManager>();
         var rbacService = new RbacService(userManager, libraryManager, NullLogger<RbacService>.Instance);
         var httpClientFactory = Substitute.For<IHttpClientFactory>();
+
+        // Not exercised by these tests — every session here has a null PictureUrl, so
+        // ApplyProfileImageAsync returns before touching any HTTP client.
+        HttpClient ProfileImagePinnedClientFactory(IPAddress address, bool allowAutoRedirect) => httpClientFactory.CreateClient("OidcPluginImage");
+
         var profileImageService = new ProfileImageService(
             httpClientFactory,
+            ProfileImagePinnedClientFactory,
             userManager,
             Substitute.For<IServerConfigurationManager>(),
             Substitute.For<IProviderManager>(),
@@ -61,9 +68,14 @@ public class OidcControllerTests
             appHost.GetSmartApiUrl(Arg.Any<HttpRequest>()).Returns("https://jellyfin.test");
         }
 
+        // Not exercised by the tests below (no Start/Callback coverage yet), but required to
+        // construct the controller — points at the same substitute factory's client so it stays
+        // consistent with the "OidcPlugin" mock if a test starts exercising the discovery path.
+        HttpClient PinnedClientFactory(IPAddress address, bool allowAutoRedirect) => httpClientFactory.CreateClient("OidcPlugin");
+
         var controller = new OidcController(
             stateManager, userSyncService, sessionManager, quickConnect,
-            httpClientFactory, appHost, NullLogger<OidcController>.Instance);
+            httpClientFactory, PinnedClientFactory, appHost, NullLogger<OidcController>.Instance);
 
         controller.ControllerContext = new ControllerContext
         {
@@ -377,7 +389,7 @@ public class OidcControllerTests
     public void BuildCallbackHtml_DerivesBasePathFromCallbackUrl_NotHardcodedRootRelative()
     {
         // Act
-        var html = (string)_buildCallbackHtml.Invoke(null, ["token123", "keycloak"])!;
+        var html = (string)_buildCallbackHtml.Invoke(null, ["token123", "keycloak", "nonce123"])!;
 
         // Assert — base path is derived client-side from the callback URL...
         Assert.Contains(
@@ -397,11 +409,21 @@ public class OidcControllerTests
         const string maliciousProviderId = "kc'; alert(1); //";
 
         // Act
-        var html = (string)_buildCallbackHtml.Invoke(null, ["token123", maliciousProviderId])!;
+        var html = (string)_buildCallbackHtml.Invoke(null, ["token123", maliciousProviderId, "nonce123"])!;
 
         // Assert
         Assert.Contains(System.Text.Json.JsonSerializer.Serialize(maliciousProviderId), html);
         Assert.DoesNotContain("const providerId = 'kc'", html);
+    }
+
+    [Fact]
+    public void BuildCallbackHtml_IncludesNonceOnScriptTag()
+    {
+        // Act
+        var html = (string)_buildCallbackHtml.Invoke(null, ["token123", "keycloak", "abc123=="])!;
+
+        // Assert
+        Assert.Contains("<script nonce=\"abc123==\">", html);
     }
 
     // ── BuildQuickConnectHtml ──────────────────────────────────────────────────
@@ -415,7 +437,7 @@ public class OidcControllerTests
     public void BuildQuickConnectHtml_ContainsCodeEntryFormAndBasePathPrefixedAuthorizeUrl()
     {
         // Act
-        var html = (string)_buildQuickConnectHtml.Invoke(null, ["token123", "keycloak"])!;
+        var html = (string)_buildQuickConnectHtml.Invoke(null, ["token123", "keycloak", "nonce123"])!;
 
         // Assert
         Assert.Contains("id=\"code\"", html);
@@ -434,11 +456,21 @@ public class OidcControllerTests
         const string maliciousProviderId = "kc'; alert(1); //";
 
         // Act
-        var html = (string)_buildQuickConnectHtml.Invoke(null, ["token123", maliciousProviderId])!;
+        var html = (string)_buildQuickConnectHtml.Invoke(null, ["token123", maliciousProviderId, "nonce123"])!;
 
         // Assert
         Assert.Contains(System.Text.Json.JsonSerializer.Serialize(maliciousProviderId), html);
         Assert.DoesNotContain("const providerId = 'kc'", html);
+    }
+
+    [Fact]
+    public void BuildQuickConnectHtml_IncludesNonceOnScriptTag()
+    {
+        // Act
+        var html = (string)_buildQuickConnectHtml.Invoke(null, ["token123", "keycloak", "abc123=="])!;
+
+        // Assert
+        Assert.Contains("<script nonce=\"abc123==\">", html);
     }
 
     // ── QuickConnectAuthorize ──────────────────────────────────────────────────

--- a/Jellyfin.Plugin.OIDC.Tests/Services/AuthorityGuardTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/Services/AuthorityGuardTests.cs
@@ -194,4 +194,85 @@ public class AuthorityGuardTests
 
         Assert.Null(result);
     }
+
+    // ── ValidateAndResolveAsync ──────────────────────────────────────────────────
+    // Mirrors ValidateAsync's cases, plus asserting the resolved address that a caller
+    // would pin the subsequent connection to.
+
+    [Fact]
+    public async Task ValidateAndResolveAsync_PublicIpLiteralAuthority_ReturnsAddressAndNoBlockReason()
+    {
+        var (blockReason, pinnedAddress) = await AuthorityGuard.ValidateAndResolveAsync(
+            "https://8.8.8.8/", allowLoopback: false, allowLinkLocal: false, blockPrivateNetworks: false);
+
+        Assert.Null(blockReason);
+        Assert.Equal(IPAddress.Parse("8.8.8.8"), pinnedAddress);
+    }
+
+    [Fact]
+    public async Task ValidateAndResolveAsync_LoopbackIpLiteralAuthority_ReturnsBlockReason()
+    {
+        var (blockReason, _) = await AuthorityGuard.ValidateAndResolveAsync(
+            "https://127.0.0.1/realms/test", allowLoopback: false, allowLinkLocal: false, blockPrivateNetworks: false);
+
+        Assert.NotNull(blockReason);
+        Assert.Contains("loopback address", blockReason);
+    }
+
+    [Fact]
+    public async Task ValidateAndResolveAsync_LoopbackAuthority_WithLoopbackOptOut_ReturnsAddress()
+    {
+        var (blockReason, pinnedAddress) = await AuthorityGuard.ValidateAndResolveAsync(
+            "https://127.0.0.1/realms/test", allowLoopback: true, allowLinkLocal: false, blockPrivateNetworks: false);
+
+        Assert.Null(blockReason);
+        Assert.Equal(IPAddress.Parse("127.0.0.1"), pinnedAddress);
+    }
+
+    [Fact]
+    public async Task ValidateAndResolveAsync_Rfc1918Authority_BlockPrivateNetworksTrue_ReturnsBlockReason()
+    {
+        var (blockReason, _) = await AuthorityGuard.ValidateAndResolveAsync(
+            "https://10.0.40.10/", allowLoopback: false, allowLinkLocal: false, blockPrivateNetworks: true);
+
+        Assert.NotNull(blockReason);
+        Assert.Contains("private-network address", blockReason);
+    }
+
+    [Fact]
+    public async Task ValidateAndResolveAsync_MalformedAuthority_ReturnsNullReasonAndNullAddress()
+    {
+        var (blockReason, pinnedAddress) = await AuthorityGuard.ValidateAndResolveAsync(
+            "not-a-valid-url", allowLoopback: false, allowLinkLocal: false, blockPrivateNetworks: false);
+
+        Assert.Null(blockReason);
+        Assert.Null(pinnedAddress);
+    }
+
+    // ── CreatePinnedHttpClient ────────────────────────────────────────────────────
+
+    [Fact]
+    public void CreatePinnedHttpClient_ReturnsUsableHttpClient()
+    {
+        // Socket-level pinning behavior needs a real network peer to verify end-to-end, so this
+        // only confirms the factory produces a valid, distinct HttpClient per call — the actual
+        // ConnectCallback wiring is the standard documented SocketsHttpHandler pinning pattern,
+        // verified by inspection rather than a unit test here.
+        using var client1 = AuthorityGuard.CreatePinnedHttpClient(IPAddress.Parse("8.8.8.8"));
+        using var client2 = AuthorityGuard.CreatePinnedHttpClient(IPAddress.Parse("8.8.8.8"));
+
+        Assert.NotNull(client1);
+        Assert.NotSame(client1, client2);
+    }
+
+    [Fact]
+    public void CreatePinnedHttpClient_AllowAutoRedirectFalse_ReturnsUsableHttpClient()
+    {
+        // Same rationale as above — the AllowAutoRedirect wiring is a single property
+        // assignment onto SocketsHttpHandler, verified by inspection rather than reflecting
+        // into BCL internals (fragile across .NET versions) to assert the flag directly.
+        using var client = AuthorityGuard.CreatePinnedHttpClient(IPAddress.Parse("8.8.8.8"), allowAutoRedirect: false);
+
+        Assert.NotNull(client);
+    }
 }

--- a/Jellyfin.Plugin.OIDC.Tests/Services/ProfileImageServiceTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/Services/ProfileImageServiceTests.cs
@@ -39,6 +39,11 @@ public class ProfileImageServiceTests
         var httpClientFactory = Substitute.For<IHttpClientFactory>();
         httpClientFactory.CreateClient("OidcPluginImage").Returns(new HttpClient(handler));
 
+        // Test URLs are IP literals (see PublicPictureUrl/LoopbackPictureUrl), so
+        // AuthorityGuard always resolves a pinned address — route the pinned path through the
+        // same mock handler instead of a real socket connection.
+        HttpClient PinnedClientFactory(IPAddress _, bool __) => new(handler);
+
         var userManager = Substitute.For<IUserManager>();
         userManager.UpdateUserAsync(Arg.Any<User>()).Returns(Task.CompletedTask);
         userManager.ClearProfileImageAsync(Arg.Any<User>()).Returns(Task.CompletedTask);
@@ -52,7 +57,7 @@ public class ProfileImageServiceTests
         serverConfigManager.ApplicationPaths.Returns(appPaths);
 
         var service = new ProfileImageService(
-            httpClientFactory, userManager, serverConfigManager, providerManager, NullLogger<ProfileImageService>.Instance);
+            httpClientFactory, PinnedClientFactory, userManager, serverConfigManager, providerManager, NullLogger<ProfileImageService>.Instance);
 
         return (service, userManager, providerManager);
     }

--- a/Jellyfin.Plugin.OIDC.Tests/Services/UserSyncServiceTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/Services/UserSyncServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
@@ -29,8 +30,12 @@ public class UserSyncServiceTests
     {
         var libraryManager = Substitute.For<ILibraryManager>();
         var rbac = new RbacService(userManager, libraryManager, NullLogger<RbacService>.Instance);
+        // Not exercised by these tests (no profile-image sync coverage here).
+        HttpClient PinnedClientFactory(IPAddress address, bool allowAutoRedirect) => new();
+
         var profileImageService = new ProfileImageService(
             Substitute.For<IHttpClientFactory>(),
+            PinnedClientFactory,
             userManager,
             Substitute.For<IServerConfigurationManager>(),
             Substitute.For<IProviderManager>(),

--- a/Jellyfin.Plugin.OIDC/Api/ConfigController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/ConfigController.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using IdentityModel.Client;
@@ -21,12 +22,18 @@ public class ConfigController : ControllerBase
 
     private readonly RbacService _rbacService;
     private readonly IHttpClientFactory _httpClientFactory;
+    private readonly Func<IPAddress, bool, HttpClient> _pinnedHttpClientFactory;
     private readonly ILogger<ConfigController> _logger;
 
-    public ConfigController(RbacService rbacService, IHttpClientFactory httpClientFactory, ILogger<ConfigController> logger)
+    public ConfigController(
+        RbacService rbacService,
+        IHttpClientFactory httpClientFactory,
+        Func<IPAddress, bool, HttpClient> pinnedHttpClientFactory,
+        ILogger<ConfigController> logger)
     {
         _rbacService = rbacService;
         _httpClientFactory = httpClientFactory;
+        _pinnedHttpClientFactory = pinnedHttpClientFactory;
         _logger = logger;
     }
 
@@ -59,7 +66,7 @@ public class ConfigController : ControllerBase
         }
 
         var blockPrivateNetworks = OidcPlugin.Instance?.Configuration?.BlockPrivateNetworkAuthorities ?? false;
-        var blockReason = await AuthorityGuard.ValidateAsync(
+        var (blockReason, pinnedAddress) = await AuthorityGuard.ValidateAndResolveAsync(
             request.Authority,
             request.AllowLoopbackAuthority,
             request.AllowLinkLocalAuthority,
@@ -70,7 +77,11 @@ public class ConfigController : ControllerBase
             return Ok(new { Success = false, Error = blockReason });
         }
 
-        var httpClient = _httpClientFactory.CreateClient("OidcPlugin");
+        // Pin to the exact address the guard just validated — see GetDiscoveryDocumentAsync in
+        // OidcController for why (DNS-rebinding TOCTOU).
+        using var httpClient = pinnedAddress != null
+            ? _pinnedHttpClientFactory(pinnedAddress, true)
+            : _httpClientFactory.CreateClient("OidcPlugin");
         var disco = await httpClient.GetDiscoveryDocumentAsync(new DiscoveryDocumentRequest
         {
             Address = request.Authority,

--- a/Jellyfin.Plugin.OIDC/Api/OidcController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/OidcController.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
@@ -36,6 +37,7 @@ public class OidcController : ControllerBase
     private readonly ISessionManager _sessionManager;
     private readonly IQuickConnect _quickConnect;
     private readonly IHttpClientFactory _httpClientFactory;
+    private readonly Func<IPAddress, bool, HttpClient> _pinnedHttpClientFactory;
     private readonly IServerApplicationHost _appHost;
     private readonly ILogger<OidcController> _logger;
 
@@ -45,6 +47,7 @@ public class OidcController : ControllerBase
         ISessionManager sessionManager,
         IQuickConnect quickConnect,
         IHttpClientFactory httpClientFactory,
+        Func<IPAddress, bool, HttpClient> pinnedHttpClientFactory,
         IServerApplicationHost appHost,
         ILogger<OidcController> logger)
     {
@@ -53,6 +56,7 @@ public class OidcController : ControllerBase
         _sessionManager = sessionManager;
         _quickConnect = quickConnect;
         _httpClientFactory = httpClientFactory;
+        _pinnedHttpClientFactory = pinnedHttpClientFactory;
         _appHost = appHost;
         _logger = logger;
     }
@@ -84,7 +88,7 @@ public class OidcController : ControllerBase
         }
 
         var blockPrivateNetworks = OidcPlugin.Instance?.Configuration?.BlockPrivateNetworkAuthorities ?? false;
-        var blockReason = await AuthorityGuard.ValidateAsync(
+        var (blockReason, pinnedAddress) = await AuthorityGuard.ValidateAndResolveAsync(
             provider.Authority,
             provider.AllowLoopbackAuthority,
             provider.AllowLinkLocalAuthority,
@@ -95,7 +99,7 @@ public class OidcController : ControllerBase
             return StatusCode(502, "Failed to contact identity provider");
         }
 
-        var disco = await GetDiscoveryDocumentAsync(provider).ConfigureAwait(false);
+        var disco = await GetDiscoveryDocumentAsync(provider, pinnedAddress).ConfigureAwait(false);
         if (disco.IsError)
         {
             _logger.LogError("OIDC discovery failed for {Provider}: {Error}", providerId, disco.Error);
@@ -205,7 +209,7 @@ public class OidcController : ControllerBase
         }
 
         var blockPrivateNetworks = OidcPlugin.Instance?.Configuration?.BlockPrivateNetworkAuthorities ?? false;
-        var blockReason = await AuthorityGuard.ValidateAsync(
+        var (blockReason, pinnedAddress) = await AuthorityGuard.ValidateAndResolveAsync(
             provider.Authority,
             provider.AllowLoopbackAuthority,
             provider.AllowLinkLocalAuthority,
@@ -216,7 +220,7 @@ public class OidcController : ControllerBase
             return StatusCode(502, "Failed to contact identity provider");
         }
 
-        var disco = await GetDiscoveryDocumentAsync(provider).ConfigureAwait(false);
+        var disco = await GetDiscoveryDocumentAsync(provider, pinnedAddress).ConfigureAwait(false);
         if (disco.IsError)
         {
             _logger.LogError("OIDC discovery failed for {Provider}: {Error}", providerId, disco.Error);
@@ -404,16 +408,21 @@ public class OidcController : ControllerBase
             return StatusCode(503, "Server is busy. Please try again in a moment.");
         }
 
+        // A per-response nonce lets the CSP require it on the inline script instead of
+        // 'unsafe-inline' — pure defense-in-depth, since the script's only dynamic content is
+        // already JSON-encoded below.
+        var nonce = Convert.ToBase64String(RandomNumberGenerator.GetBytes(16));
+
         Response.Headers["X-Frame-Options"] = "DENY";
         Response.Headers["X-Content-Type-Options"] = "nosniff";
-        Response.Headers["Content-Security-Policy"] = "default-src 'none'; script-src 'unsafe-inline'; connect-src 'self'; frame-ancestors 'none'";
+        Response.Headers["Content-Security-Policy"] = $"default-src 'none'; script-src 'nonce-{nonce}'; connect-src 'self'; frame-ancestors 'none'";
 
         if (oidcState.QuickConnect)
         {
-            return Content(BuildQuickConnectHtml(sessionToken, providerId), "text/html");
+            return Content(BuildQuickConnectHtml(sessionToken, providerId, nonce), "text/html");
         }
 
-        return Content(BuildCallbackHtml(sessionToken, providerId), "text/html");
+        return Content(BuildCallbackHtml(sessionToken, providerId, nonce), "text/html");
     }
 
     [HttpPost("Auth/{providerId}")]
@@ -615,9 +624,15 @@ public class OidcController : ControllerBase
         return true;
     }
 
-    private async Task<DiscoveryDocumentResponse> GetDiscoveryDocumentAsync(OidcProviderConfig provider)
+    private async Task<DiscoveryDocumentResponse> GetDiscoveryDocumentAsync(OidcProviderConfig provider, IPAddress? pinnedAddress)
     {
-        var httpClient = _httpClientFactory.CreateClient("OidcPlugin");
+        // Pin the connection to the exact address AuthorityGuard already validated, so a
+        // DNS-rebinding attacker can't swap in a different (internal) address between the
+        // guard check and this request. Falls back to the shared client only when resolution
+        // failed naturally (malformed URL/DNS failure) — the fetch is left to fail on its own.
+        using var httpClient = pinnedAddress != null
+            ? _pinnedHttpClientFactory(pinnedAddress, true)
+            : _httpClientFactory.CreateClient("OidcPlugin");
         return await httpClient.GetDiscoveryDocumentAsync(new DiscoveryDocumentRequest
         {
             Address = provider.Authority,
@@ -670,7 +685,7 @@ public class OidcController : ControllerBase
         return new Parameters(pairs);
     }
 
-    private static string BuildCallbackHtml(string sessionToken, string providerId)
+    private static string BuildCallbackHtml(string sessionToken, string providerId, string nonce)
     {
         // JSON-encode both values so single quotes, backslashes, or other JS metacharacters
         // in admin-configured provider IDs cannot break out of the string literal.
@@ -684,7 +699,7 @@ public class OidcController : ControllerBase
         <body>
         <h3>Completing authentication...</h3>
         <p id="status">Please wait...</p>
-        <script>
+        <script nonce="{{nonce}}">
         (function() {
             const token = {{tokenJson}};
             const providerId = {{providerIdJson}};
@@ -736,7 +751,7 @@ public class OidcController : ControllerBase
         """;
     }
 
-    private static string BuildQuickConnectHtml(string sessionToken, string providerId)
+    private static string BuildQuickConnectHtml(string sessionToken, string providerId, string nonce)
     {
         // JSON-encode both values so single quotes, backslashes, or other JS metacharacters
         // in admin-configured provider IDs cannot break out of the string literal.
@@ -777,7 +792,7 @@ public class OidcController : ControllerBase
             <button id="submit">Authorize</button>
             <div id="msg"></div>
         </div>
-        <script>
+        <script nonce="{{nonce}}">
         (function() {
             const token = {{tokenJson}};
             const providerId = {{providerIdJson}};

--- a/Jellyfin.Plugin.OIDC/Services/AuthorityGuard.cs
+++ b/Jellyfin.Plugin.OIDC/Services/AuthorityGuard.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Net;
+using System.Net.Http;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Jellyfin.Plugin.OIDC.Services;
@@ -21,10 +23,77 @@ public static class AuthorityGuard
         bool allowLinkLocal,
         bool blockPrivateNetworks)
     {
+        var (blockReason, _) = await ResolveAndCheckAsync(authority, allowLoopback, allowLinkLocal, blockPrivateNetworks)
+            .ConfigureAwait(false);
+        return blockReason;
+    }
+
+    /// <summary>
+    /// Same guard as <see cref="ValidateAsync"/>, but also returns the exact address that was
+    /// resolved and checked, so a caller can pin the subsequent HTTP connection to it instead of
+    /// re-resolving DNS — closing the TOCTOU window a DNS-rebinding attacker could otherwise use
+    /// to pass the guard with one address and connect to a different (internal) one.
+    /// </summary>
+    public static async Task<(string? BlockReason, IPAddress? PinnedAddress)> ValidateAndResolveAsync(
+        string authority,
+        bool allowLoopback,
+        bool allowLinkLocal,
+        bool blockPrivateNetworks)
+    {
+        var (blockReason, addresses) = await ResolveAndCheckAsync(authority, allowLoopback, allowLinkLocal, blockPrivateNetworks)
+            .ConfigureAwait(false);
+        return (blockReason, addresses.Length > 0 ? addresses[0] : null);
+    }
+
+    /// <summary>
+    /// Builds a one-off <see cref="HttpClient"/> whose connections are pinned to
+    /// <paramref name="pinnedAddress"/> instead of re-resolving the request's hostname via DNS.
+    /// TLS SNI/certificate hostname validation is unaffected — <see cref="SocketsHttpHandler"/>
+    /// negotiates TLS against the original request hostname regardless of the connect callback;
+    /// only the transport-level socket destination changes.
+    /// </summary>
+    /// <param name="pinnedAddress">The address to connect to, in place of a fresh DNS lookup.</param>
+    /// <param name="allowAutoRedirect">
+    /// A redirect target is a different, unvalidated destination — following it automatically
+    /// would silently defeat the pin. Discovery-document fetches keep the default (some real IdPs
+    /// legitimately redirect during discovery); callers with a stricter trust boundary, like the
+    /// profile-picture fetch, should pass <see langword="false"/>.
+    /// </param>
+    public static HttpClient CreatePinnedHttpClient(IPAddress pinnedAddress, bool allowAutoRedirect = true)
+    {
+        var handler = new SocketsHttpHandler
+        {
+            AllowAutoRedirect = allowAutoRedirect,
+            ConnectCallback = async (context, cancellationToken) =>
+            {
+                var endpoint = new IPEndPoint(pinnedAddress, context.DnsEndPoint.Port);
+                var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+                try
+                {
+                    await socket.ConnectAsync(endpoint, cancellationToken).ConfigureAwait(false);
+                    return new NetworkStream(socket, ownsSocket: true);
+                }
+                catch
+                {
+                    socket.Dispose();
+                    throw;
+                }
+            }
+        };
+
+        return new HttpClient(handler);
+    }
+
+    private static async Task<(string? BlockReason, IPAddress[] Addresses)> ResolveAndCheckAsync(
+        string authority,
+        bool allowLoopback,
+        bool allowLinkLocal,
+        bool blockPrivateNetworks)
+    {
         if (!Uri.TryCreate(authority, UriKind.Absolute, out var uri))
         {
             // Malformed URL — let the discovery fetch fail naturally and report its own generic error.
-            return null;
+            return (null, Array.Empty<IPAddress>());
         }
 
         IPAddress[] addresses;
@@ -42,7 +111,7 @@ public static class AuthorityGuard
             {
                 // DNS resolution failure isn't a guard concern — the discovery fetch will
                 // attempt (and normally fail) its own resolution and report it generically.
-                return null;
+                return (null, Array.Empty<IPAddress>());
             }
         }
 
@@ -50,24 +119,24 @@ public static class AuthorityGuard
         {
             if (!allowLoopback && IsLoopback(address))
             {
-                return $"Authority '{uri.Host}' resolves to a loopback address ({address}), which is blocked by " +
-                       "default. Enable \"Allow loopback Authority\" for this provider to override.";
+                return ($"Authority '{uri.Host}' resolves to a loopback address ({address}), which is blocked by " +
+                       "default. Enable \"Allow loopback Authority\" for this provider to override.", addresses);
             }
 
             if (!allowLinkLocal && IsLinkLocal(address))
             {
-                return $"Authority '{uri.Host}' resolves to a link-local address ({address}), which is blocked by " +
-                       "default. Enable \"Allow link-local Authority\" for this provider to override.";
+                return ($"Authority '{uri.Host}' resolves to a link-local address ({address}), which is blocked by " +
+                       "default. Enable \"Allow link-local Authority\" for this provider to override.", addresses);
             }
 
             if (blockPrivateNetworks && IsPrivateNetworkOrUla(address))
             {
-                return $"Authority '{uri.Host}' resolves to a private-network address ({address}), which is " +
-                       "blocked by the \"Block RFC1918/ULA Authorities\" plugin setting.";
+                return ($"Authority '{uri.Host}' resolves to a private-network address ({address}), which is " +
+                       "blocked by the \"Block RFC1918/ULA Authorities\" plugin setting.", addresses);
             }
         }
 
-        return null;
+        return (null, addresses);
     }
 
     public static bool IsLoopback(IPAddress address) => IPAddress.IsLoopback(address);

--- a/Jellyfin.Plugin.OIDC/Services/ProfileImageService.cs
+++ b/Jellyfin.Plugin.OIDC/Services/ProfileImageService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
@@ -19,6 +20,7 @@ public class ProfileImageService
     private const long MaxProfileImageBytes = 5 * 1024 * 1024;
 
     private readonly IHttpClientFactory _httpClientFactory;
+    private readonly Func<IPAddress, bool, HttpClient> _pinnedHttpClientFactory;
     private readonly IUserManager _userManager;
     private readonly IServerConfigurationManager _serverConfigurationManager;
     private readonly IProviderManager _providerManager;
@@ -26,12 +28,14 @@ public class ProfileImageService
 
     public ProfileImageService(
         IHttpClientFactory httpClientFactory,
+        Func<IPAddress, bool, HttpClient> pinnedHttpClientFactory,
         IUserManager userManager,
         IServerConfigurationManager serverConfigurationManager,
         IProviderManager providerManager,
         ILogger<ProfileImageService> logger)
     {
         _httpClientFactory = httpClientFactory;
+        _pinnedHttpClientFactory = pinnedHttpClientFactory;
         _userManager = userManager;
         _serverConfigurationManager = serverConfigurationManager;
         _providerManager = providerManager;
@@ -62,7 +66,7 @@ public class ProfileImageService
         var provider = OidcPlugin.Instance?.Configuration?.Providers
             .FirstOrDefault(p => string.Equals(p.ProviderId, providerId, StringComparison.OrdinalIgnoreCase));
         var blockPrivateNetworks = OidcPlugin.Instance?.Configuration?.BlockPrivateNetworkAuthorities ?? false;
-        var blockReason = await AuthorityGuard.ValidateAsync(
+        var (blockReason, pinnedAddress) = await AuthorityGuard.ValidateAndResolveAsync(
             pictureUrl,
             provider?.AllowLoopbackAuthority ?? false,
             provider?.AllowLinkLocalAuthority ?? false,
@@ -75,7 +79,14 @@ public class ProfileImageService
 
         try
         {
-            var httpClient = _httpClientFactory.CreateClient("OidcPluginImage");
+            // Pin to the exact address the guard just validated — closes the same DNS-rebinding
+            // TOCTOU window as the discovery fetch (see AuthorityGuard.ValidateAndResolveAsync).
+            // Redirects stay disabled either way: a redirect target is unvalidated, and this
+            // path's trust boundary is stricter than discovery's (picture claims can be
+            // end-user-influenced on some IdPs).
+            using var httpClient = pinnedAddress != null
+                ? _pinnedHttpClientFactory(pinnedAddress, false)
+                : _httpClientFactory.CreateClient("OidcPluginImage");
             using var response = await httpClient.GetAsync(pictureUrl).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {

--- a/Jellyfin.Plugin.OIDC/Services/ServiceRegistrator.cs
+++ b/Jellyfin.Plugin.OIDC/Services/ServiceRegistrator.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Plugins;
@@ -13,10 +14,17 @@ public class ServiceRegistrator : IPluginServiceRegistrator
         serviceCollection.AddSingleton<StateManager>();
         serviceCollection.AddHostedService(sp => sp.GetRequiredService<StateManager>());
 
-        // Dedicated client for profile-image downloads: redirects disabled so a validated
+        // Fallback for profile-image downloads when AuthorityGuard can't resolve a pinned
+        // address (malformed URL / DNS failure) — redirects still disabled so a validated
         // picture URL can't be used to bounce the request to an unvalidated internal host.
         serviceCollection.AddHttpClient("OidcPluginImage")
             .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { AllowAutoRedirect = false });
+
+        // Injected (rather than called statically) so tests can substitute a mock-backed
+        // HttpClient in place of a real pinned socket connection. The bool selects whether
+        // redirects are followed — false for the profile-picture fetch (its trust boundary is
+        // stricter: a redirect target is unvalidated), true (the default) for discovery fetches.
+        serviceCollection.AddSingleton<Func<IPAddress, bool, HttpClient>>(_ => AuthorityGuard.CreatePinnedHttpClient);
 
         serviceCollection.AddScoped<RbacService>();
         serviceCollection.AddScoped<ProfileImageService>();


### PR DESCRIPTION
## Stacked on #11 (fix/ssrf-picture-url)
This branch is stacked on `fix/ssrf-picture-url` because pinning the picture-fetch connection needs that PR's `AuthorityGuard` integration in `ProfileImageService` to already exist. **Merge #11 first** — this PR's diff against `dev` will include #11's changes until then, and will shrink to just this PR's changes once #11 merges and this branch is retargeted/rebased onto `dev`.

## Summary
`AuthorityGuard.ValidateAsync` resolved the Authority's DNS once to check for loopback/link-local/RFC1918, then discarded the result. The actual discovery-document fetch (and, since #11, the picture-fetch) re-resolved DNS independently — a DNS-rebinding attacker controlling the Authority domain (or a picture-claim host) could pass the guard with a public IP, then rebind to an internal address for the real request.

## Changes
- Add `AuthorityGuard.ValidateAndResolveAsync`, which returns the exact address that was resolved and checked alongside the block reason.
- Add `AuthorityGuard.CreatePinnedHttpClient(address, allowAutoRedirect)`, a one-off `HttpClient` whose connections are pinned to that address via a `SocketsHttpHandler.ConnectCallback` — TLS SNI/certificate validation is unaffected, only the transport-level socket destination changes. `allowAutoRedirect` defaults to `true` for discovery fetches (some real IdPs redirect during discovery); the picture fetch passes `false`, since a redirect target is an unvalidated destination and that path's trust boundary is stricter (picture claims can be end-user-influenced on some IdPs).
- Wire pinning into `OidcController`'s discovery fetch (`Start`/`Callback`), `ConfigController`'s `TestProvider`, and `ProfileImageService`'s picture fetch. The pinned-client factory is injected as `Func<IPAddress, bool, HttpClient>` rather than called statically, so tests can substitute a mock-backed `HttpClient` in place of a real pinned socket connection.

Also bundled in (small, unrelated hardening that touches the same callback response-building code): the OIDC callback page's CSP now uses a per-response nonce instead of `'unsafe-inline'` for its inline script — pure defense-in-depth, since the script's only dynamic content was already JSON-encoded.

## Test plan
- [x] `dotnet build -c Release` — clean
- [x] `dotnet test -c Release` — 191/191 passing, including new `ValidateAndResolveAsync`/`CreatePinnedHttpClient` coverage and CSP-nonce script-tag assertions