### PR TITLE
fix(security): deny login when no RBAC role mapping matches (fail-closed)

### DIFF
--- a/Jellyfin.Plugin.OIDC.Tests/Services/RbacServiceTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/Services/RbacServiceTests.cs
@@ -105,7 +105,7 @@ public class RbacServiceTests
     // ── provider filter ────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task ProviderFilter_NonMatchingProvider_SkipsMapping()
+    public async Task ProviderFilter_NonMatchingProvider_LoginDenied()
     {
         // Arrange — mapping is scoped to "keycloak"; user comes from "okta"
         var userId = Guid.NewGuid();
@@ -120,8 +120,9 @@ public class RbacServiceTests
         });
 
         // Act
-        await MakeService(userManager, Substitute.For<ILibraryManager>())
-            .ApplyRoleMappingsAsync(userId, ["admins"], "okta");
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            MakeService(userManager, Substitute.For<ILibraryManager>())
+                .ApplyRoleMappingsAsync(userId, ["admins"], "okta"));
 
         // Assert
         await userManager.DidNotReceive().UpdatePolicyAsync(Arg.Any<Guid>(), Arg.Any<UserPolicy>());
@@ -209,7 +210,7 @@ public class RbacServiceTests
     }
 
     [Fact]
-    public async Task NoMatch_NoDefault_UpdatePolicyNotCalled()
+    public async Task NoMatch_NoDefault_LoginDeniedAndPolicyNotChanged()
     {
         // Arrange
         var userId = Guid.NewGuid();
@@ -222,10 +223,35 @@ public class RbacServiceTests
         });
 
         // Act
-        await MakeService(userManager, Substitute.For<ILibraryManager>())
-            .ApplyRoleMappingsAsync(userId, ["viewers"], "keycloak");
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            MakeService(userManager, Substitute.For<ILibraryManager>())
+                .ApplyRoleMappingsAsync(userId, ["viewers"], "keycloak"));
 
         // Assert
+        Assert.Contains("No role mapping matched", exception.Message);
+        await userManager.DidNotReceive().UpdatePolicyAsync(Arg.Any<Guid>(), Arg.Any<UserPolicy>());
+    }
+
+    [Fact]
+    public async Task NoMatch_DefaultRoleDoesNotExist_LoginDeniedAndPolicyNotChanged()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var userManager = Substitute.For<IUserManager>();
+        userManager.GetUserById(userId).Returns(MakeUser());
+        _fixture.SetConfiguration(new PluginConfiguration
+        {
+            DefaultRoleName = "missing-default",
+            RoleMappings = [new RoleMapping { RoleName = "admins", IsAdmin = true }]
+        });
+
+        // Act
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            MakeService(userManager, Substitute.For<ILibraryManager>())
+                .ApplyRoleMappingsAsync(userId, ["viewers"], "keycloak"));
+
+        // Assert
+        Assert.Contains("No role mapping matched", exception.Message);
         await userManager.DidNotReceive().UpdatePolicyAsync(Arg.Any<Guid>(), Arg.Any<UserPolicy>());
     }
 

--- a/Jellyfin.Plugin.OIDC/Services/RbacService.cs
+++ b/Jellyfin.Plugin.OIDC/Services/RbacService.cs
@@ -65,9 +65,11 @@ public class RbacService
 
         if (matchedMappings.Count == 0)
         {
-            _logger.LogInformation("No role mappings matched for user {Username} with roles [{Roles}]",
+            _logger.LogWarning(
+                "Login denied: no role mappings matched for user {Username} with roles [{Roles}] and no valid default role was configured",
                 user.Username, string.Join(", ", userRoles));
-            return;
+            throw new InvalidOperationException(
+                $"No role mapping matched user '{user.Username}'. Configure a matching role or a non-privileged default role.");
         }
 
         var merged = MergeMappings(matchedMappings);

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ These changes are not present in the upstream plugin:
 - **Flexible claim parsing** — extract roles from nested JWT claims (e.g. `realm_access.roles`, `groups`)
 - **Merge semantics** — users with multiple roles get the union of all permissions (most permissive wins)
 - **Default role fallback** — assign a baseline role to users with no matching IdP roles
+- **Fail-closed RBAC** — deny login when no IdP role or configured default role matches, preventing stale permissions from surviving role removal
 - **Admin UI** — full configuration from the Jellyfin dashboard (Providers, Role Mappings, General settings)
 - **Login button injection** — paste one HTML snippet into Jellyfin's Login Disclaimer; buttons appear automatically
 - **Native/mobile app login** — sign in Android, iOS, and TV apps via Jellyfin [Quick Connect](#mobile--native-apps-quick-connect)
@@ -146,7 +147,7 @@ Go to **General tab** and configure:
 | Setting                           | Default | Description |
 |-----------------------------------|---------|-------------|
 | Auto-create users                 | On      | Create a Jellyfin account on first SSO login |
-| Default Role                      | —       | Fallback role when no IdP role matches a mapping |
+| Default Role                      | —       | Fallback role when no IdP role matches a mapping; login is denied if neither a role nor a valid default matches |
 | Migrate local users to SSO        | Off     | Switch existing password accounts to SSO auth on first SSO login |
 | Sync display name from OIDC token | Off     | Rename the Jellyfin account to match the IdP display name on each login |
 
@@ -256,7 +257,7 @@ Each role mapping has a priority field. Higher priority roles take precedence in
 
 ### Default Role
 
-If no role mappings match a user's IdP roles, the **Default Role** (configured in the General tab) is used as a fallback.
+If no role mappings match a user's IdP roles, the **Default Role** (configured in the General tab) is used as a fallback. If neither a role mapping nor a valid Default Role matches, login is denied — the plugin never falls back to Jellyfin's stock default permissions or lets a user keep a policy from a previous login. This is deliberate: it stops a role or role mapping removed at the IdP or in plugin config from silently leaving a user with access they should no longer have.
 
 ### Multi-provider role isolation
 


### PR DESCRIPTION
## Summary
Previously, if an authenticated OIDC user's IdP roles matched no configured role mapping (and no valid Default Role), `ApplyRoleMappingsAsync` silently skipped applying any policy and login proceeded anyway — with whatever permissions the user already had:
- **Existing user:** their prior `UserPolicy` is never revoked or re-evaluated. Removing a user's role at the IdP, or removing/renaming a role mapping, had no effect on their actual Jellyfin access — they'd keep it indefinitely.
- **Newly auto-created user:** they'd get Jellyfin's stock default policy, which the admin never explicitly granted via RBAC.

Credit to [@kylmp](https://github.com/kylmp)'s fork for identifying and fixing this — this PR ports that fix (`RbacService`, tests, README) into this repo.

## Changes
- `RbacService.ApplyRoleMappingsAsync` now throws `InvalidOperationException` instead of silently returning when no role mapping matches.
- Both `Authenticate` and `QuickConnectAuthorize` in `OidcController` already catch `InvalidOperationException` around this call site (originally added for `SyncUserAsync`'s failures) and convert it to `Forbid()` — so this denies login cleanly through existing, tested plumbing, no new error handling needed.
- README updated (feature list, General-tab settings table, and the Default Role section) to document this as intentional fail-closed behavior.

## This is an unconditional, intentional behavior change
Deployments relying on "no mapping match falls through to default Jellyfin permissions" will now see those logins denied (`403 Forbidden`) until a matching role mapping or a valid Default Role is configured. This is the correct default: fail-closed authorization instead of fail-open.

## Test plan
- [x] `dotnet build -c Release` — clean
- [x] `dotnet test -c Release` — 196/196 passing, including updated `ProviderFilter_NonMatchingProvider_LoginDenied`, `NoMatch_NoDefault_LoginDeniedAndPolicyNotChanged`, and a new `NoMatch_DefaultRoleDoesNotExist_LoginDeniedAndPolicyNotChanged` test