### PR TITLE
fix: declare style-src in CSP and nonce the QuickConnect style tag

### DIFF
--- a/Jellyfin.Plugin.OIDC.Tests/Api/OidcControllerTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/Api/OidcControllerTests.cs
@@ -464,13 +464,14 @@ public class OidcControllerTests
     }
 
     [Fact]
-    public void BuildQuickConnectHtml_IncludesNonceOnScriptTag()
+    public void BuildQuickConnectHtml_IncludesNonceOnScriptAndStyleTags()
     {
         // Act
         var html = (string)_buildQuickConnectHtml.Invoke(null, ["token123", "keycloak", "abc123=="])!;
 
         // Assert
         Assert.Contains("<script nonce=\"abc123==\">", html);
+        Assert.Contains("<style nonce=\"abc123==\">", html);
     }
 
     // ── Authenticate ───────────────────────────────────────────────────────────

--- a/Jellyfin.Plugin.OIDC/Api/OidcController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/OidcController.cs
@@ -408,14 +408,14 @@ public class OidcController : ControllerBase
             return StatusCode(503, "Server is busy. Please try again in a moment.");
         }
 
-        // A per-response nonce lets the CSP require it on the inline script instead of
-        // 'unsafe-inline' — pure defense-in-depth, since the script's only dynamic content is
-        // already JSON-encoded below.
+        // A per-response nonce lets the CSP authorize the inline script and styles without
+        // falling back to 'unsafe-inline'. Dynamic script values are JSON-encoded below.
         var nonce = Convert.ToBase64String(RandomNumberGenerator.GetBytes(16));
 
         Response.Headers["X-Frame-Options"] = "DENY";
         Response.Headers["X-Content-Type-Options"] = "nosniff";
-        Response.Headers["Content-Security-Policy"] = $"default-src 'none'; script-src 'nonce-{nonce}'; connect-src 'self'; frame-ancestors 'none'";
+        Response.Headers["Content-Security-Policy"] =
+            $"default-src 'none'; script-src 'nonce-{nonce}'; style-src 'nonce-{nonce}'; connect-src 'self'; frame-ancestors 'none'";
 
         if (oidcState.QuickConnect)
         {
@@ -775,7 +775,7 @@ public class OidcController : ControllerBase
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Quick Connect</title>
-        <style>
+        <style nonce="{{nonce}}">
             body { font-family: system-ui, -apple-system, sans-serif; background: #101010; color: #eee;
                    display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; }
             .card { background: #1c1c1c; padding: 2em; border-radius: 8px; max-width: 360px; width: 90%;


### PR DESCRIPTION
## Summary
The OIDC callback response's CSP declared `script-src` with a nonce but never declared `style-src`. Under `default-src 'none'`, an unspecified directive implicitly falls back to `default-src` — so `style-src` was implicitly `'none'` too, meaning the existing inline `<style>` block in the Quick Connect page was already violating CSP and would render unstyled in any browser that enforces it.

Credit to [@kylmp](https://github.com/kylmp)'s fork for identifying this — this PR ports that fix into this repo.

## Changes
- Add `style-src 'nonce-{nonce}'` alongside `script-src` in the CSP header.
- Add the matching `nonce="{{nonce}}"` attribute to the Quick Connect page's `<style>` tag.

## Test plan
- [x] `dotnet build -c Release` — clean
- [x] `dotnet test -c Release` — 195/195 passing, including updated `BuildQuickConnectHtml_IncludesNonceOnScriptAndStyleTags`