### PR TITLE
style: redesign OIDC callback page with spinner/card layout

### DIFF
--- a/Jellyfin.Plugin.OIDC.Tests/Api/OidcControllerTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/Api/OidcControllerTests.cs
@@ -417,13 +417,24 @@ public class OidcControllerTests
     }
 
     [Fact]
-    public void BuildCallbackHtml_IncludesNonceOnScriptTag()
+    public void BuildCallbackHtml_IncludesNonceOnScriptAndStyleTags()
     {
         // Act
         var html = (string)_buildCallbackHtml.Invoke(null, ["token123", "keycloak", "abc123=="])!;
 
         // Assert
         Assert.Contains("<script nonce=\"abc123==\">", html);
+        Assert.Contains("<style nonce=\"abc123==\">", html);
+    }
+
+    [Fact]
+    public void BuildCallbackHtml_StatusElementIdIsPreserved()
+    {
+        // The inline script updates status text via document.getElementById('status') —
+        // the redesigned markup must keep that id even though the surrounding tag changed.
+        var html = (string)_buildCallbackHtml.Invoke(null, ["token123", "keycloak", "abc123=="])!;
+
+        Assert.Contains("id=\"status\"", html);
     }
 
     // ── BuildQuickConnectHtml ──────────────────────────────────────────────────

--- a/Jellyfin.Plugin.OIDC/Api/OidcController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/OidcController.cs
@@ -705,10 +705,30 @@ public class OidcController : ControllerBase
         return $$"""
         <!DOCTYPE html>
         <html>
-        <head><title>Authenticating...</title></head>
+        <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Authenticating...</title>
+        <style nonce="{{nonce}}">
+            :root { color-scheme: dark; }
+            body { font-family: system-ui, -apple-system, sans-serif; background: #101010; color: #eee;
+                   display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; }
+            .card { box-sizing: border-box; background: #1c1c1c; padding: 2em; border-radius: 8px;
+                    max-width: 360px; width: 90%; box-shadow: 0 4px 24px rgba(0,0,0,.5); text-align: center; }
+            .spinner { width: 2.5em; height: 2.5em; margin: 0 auto 1.25em; border: .3em solid #444;
+                       border-top-color: #386d4b; border-radius: 50%; animation: spin .8s linear infinite; }
+            h2 { margin: 0 0 .5em; }
+            p { min-height: 1.4em; margin: 0; color: #aaa; line-height: 1.5; }
+            @keyframes spin { to { transform: rotate(360deg); } }
+            @media (prefers-reduced-motion: reduce) { .spinner { animation: none; border-top-color: #444; } }
+        </style>
+        </head>
         <body>
-        <h3>Completing authentication...</h3>
-        <p id="status">Please wait...</p>
+        <main class="card">
+            <div class="spinner" aria-hidden="true"></div>
+            <h2>Completing authentication…</h2>
+            <p id="status" role="status">Please wait…</p>
+        </main>
         <script nonce="{{nonce}}">
         (function() {
             const token = {{tokenJson}};


### PR DESCRIPTION
## Summary
Cosmetic redesign of the OIDC callback page (the "Completing authentication..." page shown briefly during login) — replaces the bare heading/paragraph with a dark-themed card, an animated loading spinner, and proper meta tags (charset, viewport, `color-scheme`).

Credit to [@kylmp](https://github.com/kylmp)'s fork for the design — this PR ports it into this repo.

## Changes
- Adds a `<style nonce="{{nonce}}">` block reusing the CSP nonce infrastructure from #15 — no CSP changes needed here since #15 already declared `style-src`.
- Spinner respects `prefers-reduced-motion`.
- The `id="status"` element the inline script updates via `document.getElementById('status')` is preserved, just re-wrapped in the new markup — verified with a new test.

No security-relevant change — purely visual. 

## Test plan
- [x] `dotnet build -c Release` — clean
- [x] `dotnet test -c Release` — 196/196 passing, including updated `BuildCallbackHtml_IncludesNonceOnScriptAndStyleTags` and a new `BuildCallbackHtml_StatusElementIdIsPreserved` test