### PR TITLE
fix(security): deny login on unmatched RBAC role (fail-closed)

### DIFF
--- a/Jellyfin.Plugin.OIDC.Tests/Api/OidcControllerTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/Api/OidcControllerTests.cs
@@ -417,13 +417,24 @@ public class OidcControllerTests
     }
 
     [Fact]
-    public void BuildCallbackHtml_IncludesNonceOnScriptTag()
+    public void BuildCallbackHtml_IncludesNonceOnScriptAndStyleTags()
     {
         // Act
         var html = (string)_buildCallbackHtml.Invoke(null, ["token123", "keycloak", "abc123=="])!;
 
         // Assert
         Assert.Contains("<script nonce=\"abc123==\">", html);
+        Assert.Contains("<style nonce=\"abc123==\">", html);
+    }
+
+    [Fact]
+    public void BuildCallbackHtml_StatusElementIdIsPreserved()
+    {
+        // The inline script updates status text via document.getElementById('status') —
+        // the redesigned markup must keep that id even though the surrounding tag changed.
+        var html = (string)_buildCallbackHtml.Invoke(null, ["token123", "keycloak", "abc123=="])!;
+
+        Assert.Contains("id=\"status\"", html);
     }
 
     // ── BuildQuickConnectHtml ──────────────────────────────────────────────────

--- a/Jellyfin.Plugin.OIDC.Tests/Api/OidcControllerTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/Api/OidcControllerTests.cs
@@ -464,13 +464,14 @@ public class OidcControllerTests
     }
 
     [Fact]
-    public void BuildQuickConnectHtml_IncludesNonceOnScriptTag()
+    public void BuildQuickConnectHtml_IncludesNonceOnScriptAndStyleTags()
     {
         // Act
         var html = (string)_buildQuickConnectHtml.Invoke(null, ["token123", "keycloak", "abc123=="])!;
 
         // Assert
         Assert.Contains("<script nonce=\"abc123==\">", html);
+        Assert.Contains("<style nonce=\"abc123==\">", html);
     }
 
     // ── Authenticate ───────────────────────────────────────────────────────────

--- a/Jellyfin.Plugin.OIDC.Tests/Services/RbacServiceTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/Services/RbacServiceTests.cs
@@ -105,7 +105,7 @@ public class RbacServiceTests
     // ── provider filter ────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task ProviderFilter_NonMatchingProvider_SkipsMapping()
+    public async Task ProviderFilter_NonMatchingProvider_LoginDenied()
     {
         // Arrange — mapping is scoped to "keycloak"; user comes from "okta"
         var userId = Guid.NewGuid();
@@ -120,8 +120,9 @@ public class RbacServiceTests
         });
 
         // Act
-        await MakeService(userManager, Substitute.For<ILibraryManager>())
-            .ApplyRoleMappingsAsync(userId, ["admins"], "okta");
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            MakeService(userManager, Substitute.For<ILibraryManager>())
+                .ApplyRoleMappingsAsync(userId, ["admins"], "okta"));
 
         // Assert
         await userManager.DidNotReceive().UpdatePolicyAsync(Arg.Any<Guid>(), Arg.Any<UserPolicy>());
@@ -209,7 +210,7 @@ public class RbacServiceTests
     }
 
     [Fact]
-    public async Task NoMatch_NoDefault_UpdatePolicyNotCalled()
+    public async Task NoMatch_NoDefault_LoginDeniedAndPolicyNotChanged()
     {
         // Arrange
         var userId = Guid.NewGuid();
@@ -222,10 +223,35 @@ public class RbacServiceTests
         });
 
         // Act
-        await MakeService(userManager, Substitute.For<ILibraryManager>())
-            .ApplyRoleMappingsAsync(userId, ["viewers"], "keycloak");
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            MakeService(userManager, Substitute.For<ILibraryManager>())
+                .ApplyRoleMappingsAsync(userId, ["viewers"], "keycloak"));
 
         // Assert
+        Assert.Contains("No role mapping matched", exception.Message);
+        await userManager.DidNotReceive().UpdatePolicyAsync(Arg.Any<Guid>(), Arg.Any<UserPolicy>());
+    }
+
+    [Fact]
+    public async Task NoMatch_DefaultRoleDoesNotExist_LoginDeniedAndPolicyNotChanged()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var userManager = Substitute.For<IUserManager>();
+        userManager.GetUserById(userId).Returns(MakeUser());
+        _fixture.SetConfiguration(new PluginConfiguration
+        {
+            DefaultRoleName = "missing-default",
+            RoleMappings = [new RoleMapping { RoleName = "admins", IsAdmin = true }]
+        });
+
+        // Act
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            MakeService(userManager, Substitute.For<ILibraryManager>())
+                .ApplyRoleMappingsAsync(userId, ["viewers"], "keycloak"));
+
+        // Assert
+        Assert.Contains("No role mapping matched", exception.Message);
         await userManager.DidNotReceive().UpdatePolicyAsync(Arg.Any<Guid>(), Arg.Any<UserPolicy>());
     }
 

--- a/Jellyfin.Plugin.OIDC/Api/OidcController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/OidcController.cs
@@ -705,10 +705,30 @@ public class OidcController : ControllerBase
         return $$"""
         <!DOCTYPE html>
         <html>
-        <head><title>Authenticating...</title></head>
+        <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Authenticating...</title>
+        <style nonce="{{nonce}}">
+            :root { color-scheme: dark; }
+            body { font-family: system-ui, -apple-system, sans-serif; background: #101010; color: #eee;
+                   display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; }
+            .card { box-sizing: border-box; background: #1c1c1c; padding: 2em; border-radius: 8px;
+                    max-width: 360px; width: 90%; box-shadow: 0 4px 24px rgba(0,0,0,.5); text-align: center; }
+            .spinner { width: 2.5em; height: 2.5em; margin: 0 auto 1.25em; border: .3em solid #444;
+                       border-top-color: #386d4b; border-radius: 50%; animation: spin .8s linear infinite; }
+            h2 { margin: 0 0 .5em; }
+            p { min-height: 1.4em; margin: 0; color: #aaa; line-height: 1.5; }
+            @keyframes spin { to { transform: rotate(360deg); } }
+            @media (prefers-reduced-motion: reduce) { .spinner { animation: none; border-top-color: #444; } }
+        </style>
+        </head>
         <body>
-        <h3>Completing authentication...</h3>
-        <p id="status">Please wait...</p>
+        <main class="card">
+            <div class="spinner" aria-hidden="true"></div>
+            <h2>Completing authentication…</h2>
+            <p id="status" role="status">Please wait…</p>
+        </main>
         <script nonce="{{nonce}}">
         (function() {
             const token = {{tokenJson}};

--- a/Jellyfin.Plugin.OIDC/Api/OidcController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/OidcController.cs
@@ -408,14 +408,14 @@ public class OidcController : ControllerBase
             return StatusCode(503, "Server is busy. Please try again in a moment.");
         }
 
-        // A per-response nonce lets the CSP require it on the inline script instead of
-        // 'unsafe-inline' — pure defense-in-depth, since the script's only dynamic content is
-        // already JSON-encoded below.
+        // A per-response nonce lets the CSP authorize the inline script and styles without
+        // falling back to 'unsafe-inline'. Dynamic script values are JSON-encoded below.
         var nonce = Convert.ToBase64String(RandomNumberGenerator.GetBytes(16));
 
         Response.Headers["X-Frame-Options"] = "DENY";
         Response.Headers["X-Content-Type-Options"] = "nosniff";
-        Response.Headers["Content-Security-Policy"] = $"default-src 'none'; script-src 'nonce-{nonce}'; connect-src 'self'; frame-ancestors 'none'";
+        Response.Headers["Content-Security-Policy"] =
+            $"default-src 'none'; script-src 'nonce-{nonce}'; style-src 'nonce-{nonce}'; connect-src 'self'; frame-ancestors 'none'";
 
         if (oidcState.QuickConnect)
         {
@@ -775,7 +775,7 @@ public class OidcController : ControllerBase
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Quick Connect</title>
-        <style>
+        <style nonce="{{nonce}}">
             body { font-family: system-ui, -apple-system, sans-serif; background: #101010; color: #eee;
                    display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; }
             .card { background: #1c1c1c; padding: 2em; border-radius: 8px; max-width: 360px; width: 90%;

--- a/Jellyfin.Plugin.OIDC/Services/RbacService.cs
+++ b/Jellyfin.Plugin.OIDC/Services/RbacService.cs
@@ -65,9 +65,11 @@ public class RbacService
 
         if (matchedMappings.Count == 0)
         {
-            _logger.LogInformation("No role mappings matched for user {Username} with roles [{Roles}]",
+            _logger.LogWarning(
+                "Login denied: no role mappings matched for user {Username} with roles [{Roles}] and no valid default role was configured",
                 user.Username, string.Join(", ", userRoles));
-            return;
+            throw new InvalidOperationException(
+                $"No role mapping matched user '{user.Username}'. Configure a matching role or a non-privileged default role.");
         }
 
         var merged = MergeMappings(matchedMappings);

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ These changes are not present in the upstream plugin:
 - **Flexible claim parsing** — extract roles from nested JWT claims (e.g. `realm_access.roles`, `groups`)
 - **Merge semantics** — users with multiple roles get the union of all permissions (most permissive wins)
 - **Default role fallback** — assign a baseline role to users with no matching IdP roles
+- **Fail-closed RBAC** — deny login when no IdP role or configured default role matches, preventing stale permissions from surviving role removal
 - **Admin UI** — full configuration from the Jellyfin dashboard (Providers, Role Mappings, General settings)
 - **Login button injection** — paste one HTML snippet into Jellyfin's Login Disclaimer; buttons appear automatically
 - **Native/mobile app login** — sign in Android, iOS, and TV apps via Jellyfin [Quick Connect](#mobile--native-apps-quick-connect)
@@ -146,7 +147,7 @@ Go to **General tab** and configure:
 | Setting                           | Default | Description |
 |-----------------------------------|---------|-------------|
 | Auto-create users                 | On      | Create a Jellyfin account on first SSO login |
-| Default Role                      | —       | Fallback role when no IdP role matches a mapping |
+| Default Role                      | —       | Fallback role when no IdP role matches a mapping; login is denied if neither a role nor a valid default matches |
 | Migrate local users to SSO        | Off     | Switch existing password accounts to SSO auth on first SSO login |
 | Sync display name from OIDC token | Off     | Rename the Jellyfin account to match the IdP display name on each login |
 
@@ -256,7 +257,7 @@ Each role mapping has a priority field. Higher priority roles take precedence in
 
 ### Default Role
 
-If no role mappings match a user's IdP roles, the **Default Role** (configured in the General tab) is used as a fallback.
+If no role mappings match a user's IdP roles, the **Default Role** (configured in the General tab) is used as a fallback. If neither a role mapping nor a valid Default Role matches, login is denied — the plugin never falls back to Jellyfin's stock default permissions or lets a user keep a policy from a previous login. This is deliberate: it stops a role or role mapping removed at the IdP or in plugin config from silently leaving a user with access they should no longer have.
 
 ### Multi-provider role isolation
 


### PR DESCRIPTION
Deny OIDC login when a user's IdP roles match no configured role
mapping and no valid Default Role is set, instead of silently
letting login through with whatever permissions the user already
had. Also declares style-src in the callback page's CSP (closing a
gap where an existing inline <style> block was already violating
CSP) and redesigns the callback page's loading UI.

Previously, RbacService.ApplyRoleMappingsAsync returned without
applying a policy when no mapping matched. For an existing user,
that meant their prior UserPolicy was never revoked or
re-evaluated — removing their role at the IdP, or removing/renaming
a role mapping, had no effect on their actual Jellyfin access. For a
newly auto-created user, they'd get Jellyfin's stock default policy,
which the admin never explicitly granted via RBAC.

RbacService.ApplyRoleMappingsAsync now throws InvalidOperationException
on no match. Authenticate and QuickConnectAuthorize in OidcController
already catch InvalidOperationException around this call site
(originally for SyncUserAsync's failures) and convert it to Forbid(),
so this denies login through existing, tested plumbing.

Also included:
- CSP: declare style-src 'nonce-{nonce}' alongside script-src on the
  OIDC callback response, and nonce the Quick Connect page's <style>
  tag, which was previously unprotected and technically already
  CSP-non-compliant under default-src 'none'.
- Callback page: cosmetic redesign (spinner, card layout, dark
  color-scheme meta) reusing the same nonce. No security-relevant
  change.
  
  
BREAKING CHANGE: deployments relying on "no role mapping match falls
through to default Jellyfin permissions" will now see those logins
denied (403) until a matching role mapping or a valid Default Role
is configured.