### PR TITLE
chore(release): update manifest.json for v1.0.7.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,14 @@
     "category": "Authentication",
     "versions": [
       {
+        "version": "1.0.7.0",
+        "changelog": "Security: deny OIDC login when no RBAC role mapping (and no valid Default Role) matches the user's IdP roles, instead of silently letting login through with stale or default permissions — an intentional, unconditional fail-closed behavior change. Fix: declare style-src in the callback page's CSP and nonce the Quick Connect page's inline styles, closing a gap where that page was already CSP-non-compliant. Also: cosmetic redesign of the OIDC callback page (spinner, card layout, dark theme).",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/aussierk/jellyfin-plugin-oidc/releases/download/v1.0.7.0/oidc-rbac.zip",
+        "checksum": "385b7c245940b4b0e43ef56ea37f309e",
+        "timestamp": "2026-08-14T22:39:05Z"
+      },
+      {
         "version": "1.0.6.1",
         "changelog": "Security: evict stale entries from the rate limiter to prevent unbounded memory growth. Security: validate the OIDC picture-claim URL (scheme, host, redirects, size) before fetching it to prevent SSRF via a malicious/compromised IdP or self-service avatar. Security: block login/Quick Connect for a provider disabled mid-flow via an already-issued session token. Security: pin discovery and picture-fetch HTTP connections to the DNS-resolved address AuthorityGuard already validated, closing a DNS-rebinding TOCTOU gap. Also: OIDC callback page CSP now uses a per-response nonce instead of 'unsafe-inline'.",
         "targetAbi": "10.11.0.0",


### PR DESCRIPTION
## Summary
Manually applies the manifest.json update that `release.yml`'s "Commit updated manifest" step tried to push directly to `main` for the v1.0.7.0 release and got rejected by branch protection ("Changes must be made through a pull request").

Content is taken verbatim from the `manifest.json` asset already attached to the [v1.0.7.0 release](https://github.com/aussierk/jellyfin-plugin-oidc/releases/tag/v1.0.7.0) — same checksum, same sourceUrl, nothing recomputed.

**This will happen on every future release** until `release.yml` is updated to open a PR instead of pushing directly to `main`, or branch protection is relaxed for that step. Flagging separately — not fixing the workflow in this PR.