### PR TITLE
chore(release): prepare release for Jellyfin 12.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
+# Push builds on main/dev are covered by release.yml / dev-prerelease.yml, so CI
+# only needs to gate pull requests.
 on:
-  push:
-    branches: ["main", "dev"]
   pull_request:
     branches: ["main", "dev"]
 

--- a/.github/workflows/dev-prerelease.yml
+++ b/.github/workflows/dev-prerelease.yml
@@ -1,0 +1,131 @@
+name: Dev Pre-release
+
+# Every merge/push to `dev` builds a testing package, publishes it as a GitHub
+# pre-release, and updates `dev`'s manifest.json (the Testing channel).
+#
+# IMPORTANT: Jellyfin parses each manifest `version` with System.Version, which
+# only accepts 2-4 dotted integers. A semver suffix like "1.0.7.1-rc.1" makes
+# Jellyfin throw ("Version string portion was too short or too long") and breaks
+# the whole plugin catalog. So:
+#   - the manifest `version` is the plain <csproj Version> (e.g. 1.0.7.1)
+#   - the "-rc.<run number>" suffix lives ONLY in the git tag / GitHub pre-release
+#   - each dev merge for the same <Version> REPLACES that manifest entry in place
+#     (new bits, same version number) until the version is bumped for the next cycle
+#
+# The manifest commit back to `dev` carries "[skip ci]" so it does not re-trigger.
+
+on:
+  push:
+    branches: ["dev"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: dev-prerelease
+  cancel-in-progress: false
+
+jobs:
+  prerelease:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Test
+        run: dotnet test -c Release --logger "console;verbosity=normal"
+
+      - name: Compute version
+        id: version
+        run: |
+          BASE=$(grep -oP '(?<=<Version>)[^<]+' Jellyfin.Plugin.OIDC/Jellyfin.Plugin.OIDC.csproj)
+          # Must be plain N.N[.N[.N]] for Jellyfin's System.Version parser.
+          if ! [[ "$BASE" =~ ^[0-9]+(\.[0-9]+){1,3}$ ]]; then
+            echo "::error::<Version> '$BASE' is not a plain numeric version (2-4 dotted integers)."
+            exit 1
+          fi
+          # If v$BASE (the full-release tag) already exists, this version already
+          # shipped to Stable — bump <Version> before cutting more dev builds.
+          if git ls-remote --exit-code --tags origin "refs/tags/v${BASE}" >/dev/null 2>&1; then
+            echo "::error::v${BASE} is already released. Bump <Version> in the csproj for the next cycle."
+            exit 1
+          fi
+          echo "base=${BASE}"                       >> "$GITHUB_OUTPUT"
+          echo "rc_tag=v${BASE}-rc.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Build
+        run: dotnet publish Jellyfin.Plugin.OIDC/Jellyfin.Plugin.OIDC.csproj -c Release -o dist
+
+      - name: Package
+        run: cd dist && zip ../oidc-rbac.zip *.dll meta.json
+
+      - name: Update dev manifest
+        env:
+          BASE: ${{ steps.version.outputs.base }}
+          RC_TAG: ${{ steps.version.outputs.rc_tag }}
+        run: |
+          CHECKSUM=$(md5sum oidc-rbac.zip | cut -d' ' -f1)
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          # Artifact is hosted on the rc pre-release; the manifest version stays plain.
+          DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${RC_TAG}/oidc-rbac.zip"
+
+          META=Jellyfin.Plugin.OIDC/meta.json
+          CHANGELOG=$(jq -r --arg v "$BASE" '.versions[] | select(.version == $v) | .changelog' "$META")
+          if [ -z "$CHANGELOG" ] || [ "$CHANGELOG" = "null" ]; then
+            CHANGELOG="Testing build from ${{ github.sha }}"
+          fi
+          TARGET_ABI=$(jq -r --arg v "$BASE" '.versions[] | select(.version == $v) | .targetAbi' "$META")
+          if [ -z "$TARGET_ABI" ] || [ "$TARGET_ABI" = "null" ]; then
+            TARGET_ABI="12.0.0.0"
+          fi
+
+          NEW_ENTRY=$(jq -n \
+            --arg version    "$BASE" \
+            --arg changelog  "$CHANGELOG" \
+            --arg targetAbi  "$TARGET_ABI" \
+            --arg sourceUrl  "$DOWNLOAD_URL" \
+            --arg checksum   "$CHECKSUM" \
+            --arg timestamp  "$TIMESTAMP" \
+            '{version: $version, changelog: $changelog, targetAbi: $targetAbi, sourceUrl: $sourceUrl, checksum: $checksum, timestamp: $timestamp}')
+
+          # Replace this version's entry in place if present, else prepend it.
+          if jq -e --arg v "$BASE" '.[0].versions[] | select(.version == $v)' manifest.json > /dev/null 2>&1; then
+            jq --argjson entry "$NEW_ENTRY" \
+              '.[0].versions = [.[0].versions[] | if .version == $entry.version then $entry else . end]' \
+              manifest.json > manifest.tmp
+          else
+            jq --argjson entry "$NEW_ENTRY" \
+              '.[0].versions = [$entry] + .[0].versions' \
+              manifest.json > manifest.tmp
+          fi
+          mv manifest.tmp manifest.json
+
+      - name: Create GitHub pre-release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.version.outputs.rc_tag }}
+          target_commitish: ${{ github.sha }}
+          prerelease: true
+          generate_release_notes: true
+          files: |
+            oidc-rbac.zip
+            manifest.json
+
+      - name: Commit manifest back to dev
+        env:
+          RC_TAG: ${{ steps.version.outputs.rc_tag }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add manifest.json
+          git commit -m "chore(prerelease): update dev manifest for ${RC_TAG} [skip ci]" || { echo "No manifest change"; exit 0; }
+          git pull --rebase origin dev
+          git push origin HEAD:dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,108 +1,159 @@
-name: Build & Release
+name: Release
+
+# A merged PR to `main` cuts a full release: build + test, tag v<csproj Version>,
+# publish a GitHub release, and prepend the entry to `main`'s manifest.json (the
+# Stable channel). The same entry is also synced into `dev`'s manifest so the
+# Testing channel never regresses behind Stable.
+#
+# The release is version-gated: if the tag v<Version> already exists, the push did
+# not bump <Version> (e.g. a docs-only merge) and the workflow exits without
+# releasing. So a normal release PR must bump <Version> in the .csproj and add the
+# matching entry to Jellyfin.Plugin.OIDC/meta.json.
+#
+# Manifest commits carry "[skip ci]" so they do not re-trigger this workflow or CI.
 
 on:
   push:
-    tags:
-      - "v*"
+    branches: ["main"]
+  workflow_dispatch:
 
 permissions:
   contents: write
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: "10.0.x"
-
-      - name: Test
-        run: dotnet test -c Release --logger "console;verbosity=normal"
 
       - name: Extract version from csproj
         id: version
         run: |
           VERSION=$(grep -oP '(?<=<Version>)[^<]+' Jellyfin.Plugin.OIDC/Jellyfin.Plugin.OIDC.csproj)
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VERSION}"    >> "$GITHUB_OUTPUT"
+
+      - name: Skip if this version was already released
+        id: gate
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "released=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::${{ steps.version.outputs.tag }} already exists — <Version> was not bumped, nothing to release."
+          else
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        if: steps.gate.outputs.released == 'false'
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Test
+        if: steps.gate.outputs.released == 'false'
+        run: dotnet test -c Release --logger "console;verbosity=normal"
 
       - name: Build
+        if: steps.gate.outputs.released == 'false'
         run: dotnet publish Jellyfin.Plugin.OIDC/Jellyfin.Plugin.OIDC.csproj -c Release -o dist
 
       - name: Package
+        if: steps.gate.outputs.released == 'false'
         run: cd dist && zip ../oidc-rbac.zip *.dll meta.json
 
-      - name: Generate manifest.json
+      - name: Build manifest entry
+        if: steps.gate.outputs.released == 'false'
+        id: entry
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
           CHECKSUM=$(md5sum oidc-rbac.zip | cut -d' ' -f1)
           TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          VERSION="${{ steps.version.outputs.version }}"
-          DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}/oidc-rbac.zip"
-          CHANGELOG=$(jq -r --arg v "${VERSION}" '.versions[] | select(.version == $v) | .changelog' Jellyfin.Plugin.OIDC/meta.json)
+          DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/oidc-rbac.zip"
 
-          NEW_ENTRY=$(jq -n \
-            --arg version    "${VERSION}" \
-            --arg changelog  "${CHANGELOG}" \
-            --arg sourceUrl  "${DOWNLOAD_URL}" \
-            --arg checksum   "${CHECKSUM}" \
-            --arg timestamp  "${TIMESTAMP}" \
-            '{version: $version, changelog: $changelog, targetAbi: "10.11.0.0", sourceUrl: $sourceUrl, checksum: $checksum, timestamp: $timestamp}')
-
-          # Resolve the branch this tag was pushed from
-          SOURCE_BRANCH=$(git branch -r --contains "${{ github.sha }}" \
-            | grep -v 'HEAD' | sed 's|.*origin/||' | xargs | awk '{print $1}')
-          [ -z "$SOURCE_BRANCH" ] && SOURCE_BRANCH="main"
-          echo "SOURCE_BRANCH=${SOURCE_BRANCH}" >> "$GITHUB_ENV"
-
-          # Read the existing manifest from the source branch and prepend the new entry.
-          # If this version already exists (re-run), replace it in-place instead.
-          git show "origin/${SOURCE_BRANCH}:manifest.json" > manifest_existing.json
-
-          if jq -e --arg v "${VERSION}" '.[0].versions[] | select(.version == $v)' manifest_existing.json > /dev/null 2>&1; then
-            jq --argjson entry "${NEW_ENTRY}" \
-              '.[0].versions = [.[0].versions[] | if .version == $entry.version then $entry else . end]' \
-              manifest_existing.json > manifest.json
-          else
-            jq --argjson entry "${NEW_ENTRY}" \
-              '.[0].versions = [$entry] + .[0].versions' \
-              manifest_existing.json > manifest.json
+          META=Jellyfin.Plugin.OIDC/meta.json
+          CHANGELOG=$(jq -r --arg v "$VERSION" '.versions[] | select(.version == $v) | .changelog' "$META")
+          if [ -z "$CHANGELOG" ] || [ "$CHANGELOG" = "null" ]; then
+            echo "::error::No meta.json changelog entry for ${VERSION}. Add one in the release PR."
+            exit 1
+          fi
+          TARGET_ABI=$(jq -r --arg v "$VERSION" '.versions[] | select(.version == $v) | .targetAbi' "$META")
+          if [ -z "$TARGET_ABI" ] || [ "$TARGET_ABI" = "null" ]; then
+            TARGET_ABI="12.0.0.0"
           fi
 
-      - name: Create release
+          jq -n \
+            --arg version    "$VERSION" \
+            --arg changelog  "$CHANGELOG" \
+            --arg targetAbi  "$TARGET_ABI" \
+            --arg sourceUrl  "$DOWNLOAD_URL" \
+            --arg checksum   "$CHECKSUM" \
+            --arg timestamp  "$TIMESTAMP" \
+            '{version: $version, changelog: $changelog, targetAbi: $targetAbi, sourceUrl: $sourceUrl, checksum: $checksum, timestamp: $timestamp}' \
+            > new_entry.json
+          cat new_entry.json
+
+      - name: Update main manifest
+        if: steps.gate.outputs.released == 'false'
+        run: |
+          jq --slurpfile entry new_entry.json '
+            .[0].versions = (
+              if any(.[0].versions[]; .version == $entry[0].version)
+              then [.[0].versions[] | if .version == $entry[0].version then $entry[0] else . end]
+              else [$entry[0]] + .[0].versions
+              end
+            )' manifest.json > manifest.tmp
+          mv manifest.tmp manifest.json
+
+      - name: Create GitHub release
+        if: steps.gate.outputs.released == 'false'
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          target_commitish: ${{ github.sha }}
+          prerelease: false
+          generate_release_notes: true
           files: |
             oidc-rbac.zip
             manifest.json
-          generate_release_notes: true
-          prerelease: ${{ contains(github.ref_name, '-') }}
 
-      - name: Commit updated manifest
+      - name: Commit manifest to main and sync into dev
+        if: steps.gate.outputs.released == 'false'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          git config user.name "github-actions[bot]"
+          git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          cp manifest.json /tmp/manifest.json
+          cp manifest.json /tmp/release-manifest.json
+          cp new_entry.json /tmp/new_entry.json
 
-          # Discard the locally generated manifest so git checkout doesn't refuse
-          git restore manifest.json 2>/dev/null || git checkout -- manifest.json
-
-          # Always commit back to the source branch
-          git checkout "${SOURCE_BRANCH}"
-          cp /tmp/manifest.json manifest.json
+          # main
           git add manifest.json
-          git commit -m "chore(release): update manifest.json for ${GITHUB_REF_NAME}" || echo "No changes"
-          git push origin "${SOURCE_BRANCH}"
+          git commit -m "chore(release): update manifest.json for ${TAG} [skip ci]" || echo "No change on main"
+          git pull --rebase origin main
+          git push origin HEAD:main
 
-          # For full releases, also update main if the source branch wasn't main
-          if [[ "${GITHUB_REF_NAME}" != *"-"* ]] && [[ "${SOURCE_BRANCH}" != "main" ]]; then
-            git checkout main
-            cp /tmp/manifest.json manifest.json
-            git add manifest.json
-            git commit -m "chore(release): update manifest.json for ${GITHUB_REF_NAME}" || echo "No changes"
-            git push origin main
-          fi
+          # dev — prepend/replace the same entry so Testing keeps every Stable version
+          git fetch origin dev
+          git checkout -B dev origin/dev
+          jq --slurpfile entry /tmp/new_entry.json '
+            .[0].versions = (
+              if any(.[0].versions[]; .version == $entry[0].version)
+              then [.[0].versions[] | if .version == $entry[0].version then $entry[0] else . end]
+              else [$entry[0]] + .[0].versions
+              end
+            )' manifest.json > manifest.tmp
+          mv manifest.tmp manifest.json
+          git add manifest.json
+          git commit -m "chore(release): sync manifest.json for ${TAG} into dev [skip ci]" || { echo "dev already current"; exit 0; }
+          git pull --rebase origin dev
+          git push origin HEAD:dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 WORKDIR /src
 COPY . .

--- a/Jellyfin.Plugin.OIDC.Tests/Auth/OidcAuthProviderTests.cs
+++ b/Jellyfin.Plugin.OIDC.Tests/Auth/OidcAuthProviderTests.cs
@@ -14,10 +14,6 @@ public class OidcAuthProviderTests
             () => _provider.Authenticate("alice", "password123"));
 
     [Fact]
-    public void HasPassword_AlwaysReturnsFalse()
-        => Assert.False(_provider.HasPassword(null!));
-
-    [Fact]
     public async Task ChangePassword_AlwaysThrowsNotSupportedException()
         => await Assert.ThrowsAsync<NotSupportedException>(
             () => _provider.ChangePassword(null!, "newpass"));

--- a/Jellyfin.Plugin.OIDC.Tests/Jellyfin.Plugin.OIDC.Tests.csproj
+++ b/Jellyfin.Plugin.OIDC.Tests/Jellyfin.Plugin.OIDC.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.10" />
-    <PackageReference Include="Jellyfin.Model" Version="10.11.10" />
+    <PackageReference Include="Jellyfin.Controller" Version="12.0.0" />
+    <PackageReference Include="Jellyfin.Model" Version="12.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.OIDC/Api/OidcController.cs
+++ b/Jellyfin.Plugin.OIDC/Api/OidcController.cs
@@ -738,6 +738,9 @@ public class OidcController : ControllerBase
             // this callback was served at, so every link below keeps the prefix. Empty when unset.
             const basePath = window.location.pathname.replace(/\/sso\/OIDC\/Callback\/[^/]+\/?$/i, '');
 
+            // '_deviceId2' and 'jellyfin_credentials' below are jellyfin-web internals with no
+            // public "adopt this token" API. Verified against jellyfin-web 12.0 (apphost.js,
+            // lib/jellyfin-apiclient) — re-check on the next Jellyfin major.
             const deviceId = localStorage.getItem('_deviceId2') || crypto.randomUUID();
             localStorage.setItem('_deviceId2', deviceId);
 
@@ -749,7 +752,7 @@ public class OidcController : ControllerBase
                     DeviceId: deviceId,
                     DeviceName: navigator.userAgent.substring(0, 50),
                     App: 'Jellyfin Web',
-                    AppVersion: '10.11.0'
+                    AppVersion: '12.0.0'
                 })
             })
             .then(function(r) {

--- a/Jellyfin.Plugin.OIDC/Auth/OidcAuthProvider.cs
+++ b/Jellyfin.Plugin.OIDC/Auth/OidcAuthProvider.cs
@@ -21,11 +21,6 @@ public class OidcAuthProvider : IAuthenticationProvider
         throw new AuthenticationException("This account uses OIDC authentication. Please use the SSO login button.");
     }
 
-    public bool HasPassword(User user)
-    {
-        return false;
-    }
-
     public Task ChangePassword(User user, string newPassword)
     {
         throw new NotSupportedException("Password changes are managed by the identity provider.");

--- a/Jellyfin.Plugin.OIDC/Jellyfin.Plugin.OIDC.csproj
+++ b/Jellyfin.Plugin.OIDC/Jellyfin.Plugin.OIDC.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.OIDC</RootNamespace>
     <AssemblyName>Jellyfin.Plugin.OIDC</AssemblyName>
-    <Version>1.0.7.0</Version>
+    <Version>2.0.0.0</Version>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -15,10 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.10">
+    <PackageReference Include="Jellyfin.Controller" Version="12.0.0">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="Jellyfin.Model" Version="10.11.10">
+    <PackageReference Include="Jellyfin.Model" Version="12.0.0">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="IdentityModel" Version="7.0.0" />

--- a/Jellyfin.Plugin.OIDC/meta.json
+++ b/Jellyfin.Plugin.OIDC/meta.json
@@ -4,8 +4,15 @@
   "description": "Advanced OIDC authentication with role-based library access control",
   "overview": "OpenID Connect SSO with role-to-library mapping, multi-provider support, and a full admin configuration UI.",
   "owner": "aussierk",
-  "category": "Authentication",
+  "category": "Administration",
   "versions": [
+    {
+      "version": "2.0.0.0",
+      "changelog": "BREAKING: requires Jellyfin 12.0 or newer — this build will not load on 10.10/10.11 (stay on 1.0.7.x for those). Retargeted to .NET 10 and rebuilt against the Jellyfin 12.0 plugin API. Removed the vestigial IAuthenticationProvider.HasPassword override (dropped from the interface in 12.0). No functional changes to the OIDC login, RBAC, or Quick Connect flows.",
+      "targetAbi": "12.0.0.0",
+      "sourceUrl": "",
+      "timestamp": "2026-09-08T00:00:00Z"
+    },
     {
       "version": "1.0.7.0",
       "changelog": "Security: deny OIDC login when no RBAC role mapping (and no valid Default Role) matches the user's IdP roles, instead of silently letting login through with stale or default permissions — an intentional, unconditional fail-closed behavior change. Fix: declare style-src in the callback page's CSP and nonce the Quick Connect page's inline styles, closing a gap where that page was already CSP-non-compliant. Also: cosmetic redesign of the OIDC callback page (spinner, card layout, dark theme).",

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
+> **Version 2.0** requires **Jellyfin 12.0** or newer. On Jellyfin **10.11.x**, stay on the **1.0.7.x** line.
+
 # SSO-OIDC Authentication — Jellyfin Plugin
 
 A security-hardened Jellyfin plugin providing **OpenID Connect authentication** with **role-based library access control**.
 
 Authenticate users via any OIDC-compatible identity provider (Authentik, Keycloak, Azure AD, Okta, etc.) and automatically assign Jellyfin permissions and library access based on IdP group/role claims.
 
-> **Forked from [Ezeqielle/jellyfin-plugin-oidc](https://github.com/Ezeqielle/jellyfin-plugin-oidc)** with significant security hardening. See [Security improvements](#security-improvements) for what was changed and why.
 
 ## Security improvements
 
@@ -376,7 +377,8 @@ These are architectural constraints rather than bugs. They are documented here s
 
 ### Requirements
 
-- .NET 9.0 SDK
+- .NET 10.0 SDK
+- Jellyfin 12.0 or newer (this build targets the 12.0 plugin API and will not load on 10.10/10.11)
 
 ### Build and package
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,41 +1,87 @@
 # Release process
 
-There's no branch protection on this repo and no other maintainers, so releases don't go through PRs — just direct pushes/merges.
+Releases are automated through GitHub Actions and driven by branch merges — no manual
+tagging.
+
+## Versioning
+
+Versions keep Jellyfin's four-part `Major.Minor.Build.Revision` format (`System.Version`,
+which `meta.json` / `manifest.json` require). From `2.0.0.0` onward the first three parts
+carry [SemVer](https://semver.org/) meaning and the fourth is reserved:
+
+- **Major** — breaking changes, including raising the minimum Jellyfin `targetAbi`.
+- **Minor** — backwards-compatible features.
+- **Build** — backwards-compatible fixes (SemVer patch).
+- **Revision** — always `0` for a code release; bump only to re-package the same code.
+
+`System.Version` can't hold a pre-release suffix, so every dev build for a given `<Version>`
+shares that number; the `-rc.<n>` counter lives only in the git tag / GitHub pre-release
+(e.g. `v2.0.0.0-rc.42`). Releases `1.0.x` predate this policy — a frozen `1.0.` prefix with
+the 3rd/4th parts acting as minor/patch.
 
 ## Channels
 
-- **Stable** (`main`'s `manifest.json`) — updated only by full-release tags.
-- **Testing** (`dev`'s `manifest.json`) — updated by release-candidate tags. See the [README](README.md#release-channels) for the repository URLs users add in Jellyfin.
+- **Stable** (`main`'s `manifest.json`) — updated by `.github/workflows/release.yml` when a
+  PR is merged to `main`.
+- **Testing** (`dev`'s `manifest.json`) — updated by `.github/workflows/dev-prerelease.yml`
+  on every push/merge to `dev`.
 
-`.github/workflows/release.yml` resolves whichever branch a tag's commit lives on and updates that branch's `manifest.json` only. A non-hyphenated full-release tag additionally copies the manifest to `main` if it wasn't already on `main` — so as long as full releases are tagged from `main`, that fallback never triggers.
+See the [README](README.md#release-channels) for the repository URLs users add in Jellyfin.
 
-## Cutting a testing (RC) build
+## Testing builds — automatic
 
-1. Do feature work on `dev` (or a short-lived branch merged into `dev` with a plain `git merge`).
-2. Bump `<Version>` in `Jellyfin.Plugin.OIDC/Jellyfin.Plugin.OIDC.csproj` and add/update the matching entry in `Jellyfin.Plugin.OIDC/meta.json`.
-3. Tag from `dev` with a hyphenated suffix and push the tag:
-   ```
-   git tag v1.0.6-rc.1
-   git push origin v1.0.6-rc.1
-   ```
-4. CI builds, tests, and updates `dev`'s `manifest.json` only. Testers on the Testing repository URL see it immediately.
-5. Iterate (`v1.0.6-rc.2`, ...) as needed. Re-pushing a tag with the same csproj `<Version>` replaces that manifest entry in place.
+Every merge to `dev` runs `dev-prerelease.yml`:
 
-## Promoting to stable
+1. Builds and tests.
+2. Publishes a GitHub **pre-release** tagged `v<Version>-rc.<run number>` (e.g.
+   `v2.0.0.0-rc.42`) with `oidc-rbac.zip`. The `-rc.<n>` suffix is **only** in the git tag
+   and release name — never in the manifest.
+3. Writes `dev`'s `manifest.json` with `version` = the plain `<Version>` from
+   `Jellyfin.Plugin.OIDC/Jellyfin.Plugin.OIDC.csproj` (e.g. `2.0.0.0`), `sourceUrl` pointing
+   at the rc pre-release asset, then commits it back to `dev` with `[skip ci]`.
 
-1. Merge `dev` into `main` directly (no PR):
-   ```
-   git checkout main
-   git merge dev
-   git push origin main
-   ```
-2. Tag the full release from `main` (no hyphen):
-   ```
-   git tag v1.0.6
-   git push origin v1.0.6
-   ```
-3. CI updates `main`'s `manifest.json` — Stable channel users see the new version.
+> Jellyfin parses every manifest `version` with `System.Version` (2–4 dotted integers).
+> A value like `2.0.0.0-rc.42` throws *"Version string portion was too short or too long"*
+> and breaks the entire plugin catalog. That's why the manifest version stays plain and the
+> rc counter lives only in the tag.
+
+Because the manifest version is plain, **each dev merge for the same `<Version>` replaces
+that one manifest entry in place** (new bits, same number) until `<Version>` is bumped for
+the next cycle. Once `v<Version>` has been released to Stable, `dev-prerelease.yml` refuses
+to run until `<Version>` is bumped — otherwise it would overwrite a shipped version's entry
+with untested code.
+
+Changelog and `targetAbi` come from the `<Version>` entry in `meta.json`; if it doesn't
+exist yet the changelog falls back to `Testing build from <sha>`. Add the real `meta.json`
+entry as part of your feature work so testers see meaningful notes.
+
+## Full releases — automatic on merge to `main`
+
+`release.yml` runs on every push to `main` but is **version-gated**: it only releases when
+the tag `v<Version>` does not already exist. A docs-only or chore merge that doesn't touch
+`<Version>` is a no-op.
+
+To cut a release:
+
+1. Open a PR from `dev` (or a branch) into `main` that includes:
+   - a bump to `<Version>` in `Jellyfin.Plugin.OIDC/Jellyfin.Plugin.OIDC.csproj`, and
+   - a matching entry in `Jellyfin.Plugin.OIDC/meta.json` (version + changelog + targetAbi).
+     The workflow **fails** if this entry is missing.
+2. Merge the PR. `release.yml` then:
+   - builds and tests,
+   - creates tag `v<Version>` and a GitHub **release** with `oidc-rbac.zip`,
+   - prepends the entry to `main`'s `manifest.json` (Stable) and commits it back with
+     `[skip ci]`,
+   - syncs the same entry into `dev`'s `manifest.json` so Testing never regresses behind
+     Stable.
+
+## Re-running a build
+
+Re-running a workflow with the same version replaces that entry in the target manifest
+in place rather than adding a duplicate.
 
 ## Expected state between releases
 
-Once an RC has shipped but hasn't been promoted yet, `dev`'s manifest legitimately has entries `main`'s doesn't. That's expected divergence, not drift to reconcile.
+Before promotion, `dev`'s manifest legitimately carries a version `main`'s doesn't (the one
+being tested). That's expected divergence, not drift to reconcile. Promotion adds that same
+version's final entry to both branches, repointing `sourceUrl` at the full-release asset.

--- a/scripts/generate-repo.sh
+++ b/scripts/generate-repo.sh
@@ -22,6 +22,7 @@ TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 META_FILE="$REPO_ROOT/Jellyfin.Plugin.OIDC/meta.json"
 VERSION=$(jq -r '.versions[0].version' "$META_FILE")
 CHANGELOG=$(jq -r '.versions[0].changelog' "$META_FILE")
+TARGET_ABI=$(jq -r '.versions[0].targetAbi' "$META_FILE")
 
 if [ -n "$REPO_URL" ]; then
     SOURCE_URL="${REPO_URL%/}/oidc-rbac.zip"
@@ -32,6 +33,7 @@ fi
 jq -n \
   --arg version    "$VERSION" \
   --arg changelog  "$CHANGELOG" \
+  --arg targetAbi  "$TARGET_ABI" \
   --arg sourceUrl  "$SOURCE_URL" \
   --arg checksum   "$CHECKSUM" \
   --arg timestamp  "$TIMESTAMP" \
@@ -46,7 +48,7 @@ jq -n \
       {
         "version": $version,
         "changelog": $changelog,
-        "targetAbi": "10.11.0.0",
+        "targetAbi": $targetAbi,
         "sourceUrl": $sourceUrl,
         "checksum": $checksum,
         "timestamp": $timestamp


### PR DESCRIPTION
Prepare the release for Jellyfin 12.0 by removing IAuthenticationProvider.HasPassword(User) and by retargeted the repo at Jellyfin 12.0 with a .NET10 server target.