### PR TITLE
Update SETUP.md for PocketID example

### DIFF
--- a/examples/pocket-id/SETUP.md
+++ b/examples/pocket-id/SETUP.md
@@ -30,7 +30,7 @@ Assign users to groups via **Users** → select user → **Groups**.
 | Authority URL      | `https://your-pocket-id-instance.com`                    |
 | Client ID          | *(from Pocket ID)*                                       |
 | Client Secret      | *(from Pocket ID)*                                       |
-| Scopes             | `openid profile email`                                   |
+| Scopes             | `openid profile email groups`                                   |
 | Role Claim Path    | `groups`                                                 |
 | Username Claim     | `preferred_username`                                     |
 


### PR DESCRIPTION
Pocket-ID requires the groups scope to expose user groups.
Without this scope, authentication fails with a 403 during login with SSO.
This PR updates the Pocket-ID example in SETUP.md to include the required scope.

Tested with Pocket-ID v2.14.0 and Jellyfin v12.0.
Confirmed that adding groups resolves the 403 authentication error.